### PR TITLE
Fixes uncovered during RAC installation from GKE pod

### DIFF
--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -52,6 +52,7 @@
   with_items:
     - avahi-daemon.socket
     - avahi-daemon.service
+  ignore_errors: yes
   tags: cvu
 
 - name: Install required base OS packages

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -210,6 +210,20 @@
   with_items:
     - "{{ oracle_user_data_mounts }}"
 
+# Adding this task for the error that may subsequently in the Ansible task:
+# TASK [host-storage : Mount Oracle user mount LV devices]
+# "msg": "Error mounting /u01: mount: mount /dev/mapper/sw-u01 on /u01 failed: Structure needs cleaning"
+# [root@at-bmx-svr ~]# mount /u01
+# mount: mount /dev/mapper/sw-u01 on /u01 failed: Structure needs cleaning
+
+- name: After lazy umount and before removing fstab, ensure device integrity
+  shell: |
+    xfs_repair "{{ item.blk_device }}" -L
+    mount "{{ item.mount_point }}"
+    umount "{{ item.mount_point }}"
+  with_items:
+    - "{{ oracle_user_data_mounts }}"
+
 - name: Remove Oracle user data devices from fstab
   mount:
     fstype: "{{ item.fstype }}"


### PR DESCRIPTION
(Details are also at: https://b.corp.google.com/issues/202240337#comment24)

Uncovered 2 issues - one new, the other familiar
### Issue 1 (newly faced this one for the first time)
`install-oracle.sh` tripped up at avahi check:
```
TASK [base-provision : Disable avahi daemon] ***********************************
failed: [at-00010-svr002] (item=avahi-daemon.socket) => {"ansible_loop_var": "item", "changed": false, "item": "avahi-daemon.socket", "msg": "Could not find the requested service avahi-daemon.socket: host"}
failed: [at-00010-svr002] (item=avahi-daemon.service) => {"ansible_loop_var": "item", "changed": false, "item": "avahi-daemon.service", "msg": "Could not find the requested service avahi-daemon.service: host"}
```

This was my first RAC install after this check was recently introduced. The [corresponding code](https://github.com/google/bms-toolkit/blob/master/roles/base-provision/tasks/main.yml#L45-L55) is:
```yml
- name: Disable avahi daemon
  systemd:
    name: "{{ item }}"
    enabled: false
    state: stopped
  when:
    cluster_name is defined
  with_items:
    - avahi-daemon.socket
    - avahi-daemon.service
  tags: cvu
```

I added `ignore_errors: yes` to that task and it went past it successfully during the next run:
```bash
TASK [base-provision : Disable avahi daemon] ***********************************
failed: [at-00010-svr002] (item=avahi-daemon.socket) => {"ansible_loop_var": "item", "changed": false, "item": "avahi-daemon.socket", "msg": "Could not find the requested service avahi-daemon.socket: host"}
failed: [at-00010-svr002] (item=avahi-daemon.service) => {"ansible_loop_var": "item", "changed": false, "item": "avahi-daemon.service", "msg": "Could not find the requested service avahi-daemon.service: host"}
...ignoring

```

### Issue 2 (familiar one faced during a customer POC & just automating the solution with this PR)
[The retrospective doc [here](https://docs.google.com/document/d/12Fq6KQAd-b93smB4u2Pt6AFbvOJhN2Q0OhUkGqLr-k4/edit#) (internal) has the solution for this issue that's being automated here with this PR]

The error was:
```bash
TASK [host-storage : Mount Oracle user mount LV devices] ***********************
failed: [at-00010-svr002] (item={'purpose': 'software', 'blk_device': '/dev/mapper/sw-u01', 'name': 'u01', 'fstype': 'xfs', 'mount_point': '/u01', 'mount_opts': 'defaults'}) => {"ansible_loop_var": "item", "changed": false, "item": {"blk_device": "/dev/mapper/sw-u01", "fstype": "xfs", "mount_opts": "defaults", "mount_point": "/u01", "name": "u01", "purpose": "software"}, "msg": "Error mounting /u01: mount: mount /dev/mapper/sw-u01 on /u01 failed: Structure needs cleaning\n"}
changed: [at-00010-svr002] => (item={'purpose': 'diag', 'blk_device': '/dev/mapper/sw-u02', 'name': 'u02', 'fstype': 'xfs', 'mount_point': '/u02', 'mount_opts': 'defaults'})

PLAY RECAP *********************************************************************
at-00010-svr002            : ok=20   changed=6    unreachable=0    failed=1    skipped=5    rescued=0    ignored=1  
```

The fix being proposed with this PR was tested successfully as in the following `cleanup-oracle.sh` run:
```
TASK [brute-ora-cleanup : After lazy umount and before removing fstab, ensure device integrity] ***
changed: [at-00010-svr002] => (item={'purpose': 'software', 'blk_device': '/dev/mapper/sw-u01', 'name': 'u01', 'fstype': 'xfs', 'mount_point': '/u01', 'mount_opts': 'defaults'})
changed: [at-00010-svr002] => (item={'purpose': 'diag', 'blk_device': '/dev/mapper/sw-u02', 'name': 'u02', 'fstype': 'xfs', 'mount_point': '/u02', 'mount_opts': 'defaults'})
```
