### PR TITLE
Fix post-install DB opatch issues

### DIFF
--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -96,21 +96,6 @@
     dest: "{{ install_unzip_path }}/db_install.rsp"
   tags: rac-db,rac-db-response
 
-- name: rac-db-install | Update DB OPatch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ oracle_home }}"
-    remote_src: yes
-  with_items:
-    - "{{ opatch_patches }}"
-  when:
-    - item.release == oracle_ver
-    - item.category == "OPatch"
-    - oracle_rel != "base"
-  become: yes
-  become_user: "{{ oracle_user }}"
-  tags: rac-db,update-opatch-db
-
 - name: rac-db-install | Set installer command
   set_fact:
     installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option }}"
@@ -137,6 +122,21 @@
       - "{{ install_rac_db }}"
   tags: rac-db,rac-db-install
 
+- name: rac-db-install | Update DB OPatch
+  unarchive:
+    src: "{{ swlib_path }}/{{ item.patchfile }}"
+    dest: "{{ oracle_home }}"
+    remote_src: yes
+  with_items:
+    - "{{ opatch_patches }}"
+  when:
+    - item.release == oracle_ver
+    - item.category == "OPatch"
+    - oracle_rel != "base"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags: rac-db,update-opatch-db
+
 - name: rac-db-install | Apply one-off and OJVM patches
   become: yes
   become_user: "{{ oracle_user }}"
@@ -153,8 +153,8 @@
 - name: rac-db-install | opatch output
   debug:
     msg:
-      - "{{ apply_oneoff.cmd }}"
-      - "{{ apply_oneoff.stdout_lines }}"
+      - "{{ item.cmd }}"
+      - "{{ item.stdout_lines }}"
   with_items: "{{ apply_oneoff.results }}"
   when: item.changed
   tags: rac-db,rac-db-install,opatch


### PR DESCRIPTION
When testing a 12.2 RAC install, which has an extra HAS patch, I ran into two issues with the opatch logic:

1. Unlike the GI install, the DB install is out of place, and runInstaller actually clobbers existing content in the `ORACLE_HOME`, including the OPatch executable.  Therefore we need to update OPatch _after_ the install has completed, but before invoking it to apply one-off patches
2. The opatch output display runs a loop over the appy_oneoff results, in order to handle multiple patches if necessary.  To display the output for the given patch, we need to print `{{ item.xxx }}` objects instead of the static `{{ apply_oneoff }}` ones.