### PR TITLE
Modifying conditions for additional packages requirements on RHEL7 Marketplace, RHEL7 and OEL7 

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -69,8 +69,11 @@
     lock_timeout: 180
     enablerepo: rhui-rhel-7-server-rhui-optional-rpms
   when:
-    - install_os_packages|bool and ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
-    - redhat_repo.stat.exists|bool and rh_cloud_repo.stat.exists|bool
+    - install_os_packages | bool
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '7'
+    - redhat_repo.stat.exists | bool
+    - rh_cloud_repo.stat.exists | bool
   tags: os-packages
 
 - name: Install Oracle required packages (base/non-rhui config) for RHEL7
@@ -81,8 +84,10 @@
     enablerepo: rhel-7-server-optional-rpms
   when:
     - rh_cloud_repo is not defined
-    - install_os_packages|bool and ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
-    - redhat_repo.stat.exists|bool
+    - install_os_packages | bool
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '7'
+    - redhat_repo.stat.exists | bool
   tags: os-packages
 
 - name: Stat OL7 repo
@@ -99,8 +104,10 @@
     lock_timeout: 180
     enablerepo: ol7_optional_latest
   when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '7'
-    - oraclelinux_repo.stat.exists|bool
+    - install_os_packages | bool
+    - ansible_distribution == 'OracleLinux'
+    - ansible_distribution_major_version == '7'
+    - oraclelinux_repo.stat.exists | bool
   tags: os-packages
 
 - name: Stat OL8 repo

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -62,6 +62,17 @@
     path: /etc/yum.repos.d/rh-cloud.repo
   register: rh_cloud_repo
 
+- name: Install Oracle required packages (base/non-rhui config) for Marketplace RHEL7
+  yum:
+    name: "{{ oracle_required_rpms }}"
+    state: present
+    lock_timeout: 180
+    enablerepo: rhui-rhel-7-server-rhui-optional-rpms
+  when:
+    - install_os_packages|bool and ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
+    - redhat_repo.stat.exists|bool and rh_cloud_repo.stat.exists|bool
+  tags: os-packages
+
 - name: Install Oracle required packages (base/non-rhui config) for RHEL7
   yum:
     name: "{{ oracle_required_rpms }}"
@@ -69,8 +80,9 @@
     lock_timeout: 180
     enablerepo: rhel-7-server-optional-rpms
   when:
+    - rh_cloud_repo is not defined
     - install_os_packages|bool and ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
-    - redhat_repo.stat.exists|bool or rh_cloud_repo.stat.exists|bool
+    - redhat_repo.stat.exists|bool
   tags: os-packages
 
 - name: Stat OL7 repo
@@ -79,6 +91,17 @@
   register: oraclelinux_repo
   when:
     - install_os_packages|bool and ansible_distribution == 'OracleLinux'
+
+- name: Install Oracle required packages (base/non-rhui config) for OEL7
+  yum:
+    name: "{{ oracle_required_rpms }}"
+    state: present
+    lock_timeout: 180
+    enablerepo: ol7_optional_latest
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '7'
+    - oraclelinux_repo.stat.exists|bool
+  tags: os-packages
 
 - name: Stat OL8 repo
   stat:


### PR DESCRIPTION
## Change Description:
Modifying conditions for additional packages requirements on RHEL7 Marketplace, RHEL7 and OEL7. The adjustment comes for the optional rpms repository.  The verification for RHEL7 marketplace and RHEL differs, additional checks and name change on the repos were added.
 
## Solution Overview:
The validation against the repo names from  RHEL7 Marketplace, RHEL7 and OEL7 were updated. There are new conditions to verify one or the other version.

The change for RHEL 7 is to manage the repos names that have been changed due to end of life support. The name on RHEL7 Marketplace for the repo description is rhui-rhel-7-server-rhui-optional-rpms while on the non market place is rhel-7-server-optional-rpms.

The reason OEL 8/RHEL 8 is not considered is due to the images are available directly from gce and the name of the repo has not changed. Please let me know if this clarified this request.

## Test Commands:

time ./install-oracle.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
--instance-ssh-user marcos --instance-ssh-key ~/.ssh/id_rsa \
--backup-dest "+RECO" --ora-swlib-path /u02/swlib/ \
--ora-version 19 --ora-swlib-type gcs \
--ora-asm-disks ~/asm_disk_config.json --ora-data-mounts ~/data_mounts_config.json \
--cluster-type NONE --ora-data-diskgroup DATA --ora-reco-diskgroup RECO \
--ora-db-name orcl --ora-db-container false \
--instance-ip-addr 10.2.80.4 --instance-hostname gmz-rhel-7-9-brew --allow-install-on-vm 


time ./install-oracle.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
--instance-ssh-user marcos --instance-ssh-key ~/.ssh/id_rsa \
--backup-dest "+RECO" --ora-swlib-path /u02/swlib/ \
--ora-version 19 --ora-swlib-type gcs \
--ora-asm-disks ~/asm_disk_config.json --ora-data-mounts ~/data_mounts_config.json \
--cluster-type NONE --ora-data-diskgroup DATA --ora-reco-diskgroup RECO \
--ora-db-name orcl --ora-db-container false \
--instance-ip-addr 10.2.80.50 --instance-hostname marcos-db-ol7-8fu3 --allow-install-on-vm 



### Test Prep:

VM created with REHL7 from Market place
VM created with OEL7

### Test 1: details:
https://gist.github.com/gmarcospythian/8e39d8de1bd8d889d6ac5a069d055636

## Expected Results:
The script finishes without errors