### PR TITLE
Set the environment variable CV_ASSUME_DISTID=OEL7 before running the RDBMS and GI installers

### DIFF
--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -162,16 +162,20 @@
     msg: "Using installer cmd: {{ installer_command }}"
   tags: gi-setup
 
+- name: gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+  set_fact:
+    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat' 
+                           and (ansible_distribution_major_version | int) >= 8 
+                           and (oracle_ver_base | float) <= 19.3 
+                           else '' }}"
+  tags: gi-setup
+
 - name: gi-install | Run installer
   become: yes
   become_user: "{{ grid_user }}"
   command: "{{ installer_command }}"
   environment:
-    CV_ASSUME_DISTID: OEL7
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - (oracle_ver_base | float) <= 19.3
+    CV_ASSUME_DISTID: "{{ cv_distid }}"
   register: install_grid_software
   failed_when: "('Successfully Setup Software' not in install_grid_software.stdout) or
                 (install_grid_software.rc not in [0,6,250])"

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -164,10 +164,7 @@
 
 - name: gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
   set_fact:
-    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat' 
-                           and (ansible_distribution_major_version | int) >= 8 
-                           and (oracle_ver_base | float) <= 19.3 
-                           else '' }}"
+    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat' and (ansible_distribution_major_version | int) >= 8 and (oracle_ver_base | float) <= 19.3 else '' }}"
   tags: gi-setup
 
 - name: gi-install | Run installer

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -139,7 +139,7 @@
 
 - name: gi-install | Set installer command
   set_fact:
-    installer_command: "{{ installer_command }} -silent -responseFile {{ swlib_unzip_path }}/grid_install.rsp {{ rel_patch|default('') }} {{ mgmt_option|default('') }}"
+    installer_command: "{{ installer_command }} -silent -responseFile {{ swlib_unzip_path }}/grid_install.rsp {{ rel_patch | default('') }} {{ mgmt_option | default('') }}"
   tags: gi-setup
 
 - name: gi-install | Update GI OPatch
@@ -157,18 +157,6 @@
   become_user: "{{ grid_user }}"
   tags: gi-setup,opatch
 
-- name: gi-install | Patch OL8 CVU issue MOS note 2878100.1
-  become: yes
-  become_user: "{{ grid_user }}"
-  lineinfile:
-    path: "{{ install_unzip_path }}/cv/admin/cvu_config"
-    regexp: "^CV_ASSUME_DISTID"
-    line: "CV_ASSUME_DISTID=OEL7.8"
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - oracle_ver_base == '19.3'
-
 - name: gi-install | Information
   debug:
     msg: "Using installer cmd: {{ installer_command }}"
@@ -178,6 +166,12 @@
   become: yes
   become_user: "{{ grid_user }}"
   command: "{{ installer_command }}"
+  environment:
+    CV_ASSUME_DISTID: OEL7
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version >= '8'
+    - (oracle_ver_base | float) <= 19.3
   register: install_grid_software
   failed_when: "('Successfully Setup Software' not in install_grid_software.stdout) or
                 (install_grid_software.rc not in [0,6,250])"
@@ -304,7 +298,7 @@
   register: install_grid_plugins
   when: oracle_ver not in ['11.2.0.4.0','12.1.0.2.0']
   failed_when: "(   ('Successfully Setup Software' not in install_grid_plugins.stdout) or
-                    (install_grid_plugins.rc not in [0,6]) )
-                and
-                ('The Installer has detected that there are no config tools to execute for the specified Oracle home' not in install_grid_plugins.stdout)"
+                    (install_grid_plugins.rc not in [0,6,250]) )
+               and
+               ('The Installer has detected that there are no config tools to execute for the specified Oracle home' not in install_grid_plugins.stdout)"
   tags: gi-setup

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -177,8 +177,9 @@
   environment:
     CV_ASSUME_DISTID: "{{ cv_distid }}"
   register: install_grid_software
-  failed_when: "('Successfully Setup Software' not in install_grid_software.stdout) or
-                (install_grid_software.rc not in [0,6,250])"
+  failed_when: >
+    ('Successfully Setup Software' not in install_grid_software.stdout) or
+    (install_grid_software.rc not in [0,6,250])
   tags: gi-setup
 
 - name: gi-install | Installer output

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -162,7 +162,7 @@
     msg: "Using installer cmd: {{ installer_command }}"
   tags: gi-setup
 
-- name: gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+- name: gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 # MOS Note: 2878100.1
   set_fact:
     cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat' and (ansible_distribution_major_version | int) >= 8 and (oracle_ver_base | float) <= 19.3 else '' }}"
   tags: gi-setup

--- a/roles/rac-db-setup/tasks/rac-db-install-11.2-12.1.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install-11.2-12.1.yml
@@ -118,9 +118,9 @@
   become: yes
   become_user: "{{ oracle_user }}"
   register: install_rac_db
-  failed_when:
-    - "'Successfully Setup Software' not in install_rac_db.stdout"
-    - "install_rac_db.rc not in [0,6,250]"
+  failed_when: >
+    ('Successfully Setup Software' not in install_rac_db.stdout) or
+    (install_rac_db.rc not in [0,6,250])
   tags: rac-db,rac-db-install
 
 - name: rac-db-install | Installer output

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -121,7 +121,7 @@
     msg: "Using installer cmd: {{ installer_command }}"
   tags: rac-db,rac-db-install
 
-- name: rac-db-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+- name: rac-db-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 # MOS Note 2878100.1
   set_fact:
     cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
                            and (ansible_distribution_major_version | int) >= 8

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -121,16 +121,20 @@
     msg: "Using installer cmd: {{ installer_command }}"
   tags: rac-db,rac-db-install
 
+- name: rac-db-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+  set_fact:
+    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
+                           and (ansible_distribution_major_version | int) >= 8
+                           and (oracle_ver_base | float) <= 19.3
+                           else '' }}"
+  tags: rac-db-setup
+
 - name: rac-db-install | Run runInstaller
   command: "{{ installer_command }}"
   become: yes
   become_user: "{{ oracle_user }}"
   environment:
-    CV_ASSUME_DISTID: OEL7
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - (oracle_ver_base | float) <= 19.3
+    CV_ASSUME_DISTID: "{{ cv_distid }}"
   register: install_rac_db
   failed_when:
     - "'Successfully Setup Software' not in install_rac_db.stdout"

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -136,9 +136,9 @@
   environment:
     CV_ASSUME_DISTID: "{{ cv_distid }}"
   register: install_rac_db
-  failed_when:
-    - "'Successfully Setup Software' not in install_rac_db.stdout"
-    - "install_rac_db.rc not in [0,6,250]"
+  failed_when: >
+    ('Successfully Setup Software' not in install_rac_db.stdout) or
+    (install_rac_db.rc not in [0,6,250])
   tags: rac-db,rac-db-install
 
 - name: rac-db-install | Installer output

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -111,18 +111,6 @@
   become_user: "{{ oracle_user }}"
   tags: rac-db,update-opatch-db
 
-- name: rac-db-install | Patch OL8 CVU issue MOS note 2878100.1
-  become: yes
-  become_user: "{{ oracle_user }}"
-  lineinfile:
-    path: "{{ oracle_home }}/cv/admin/cvu_config"
-    regexp: "^CV_ASSUME_DISTID"
-    line: "CV_ASSUME_DISTID=OEL7.8"
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - oracle_ver_base == '19.3'
-
 - name: rac-db-install | Set installer command
   set_fact:
     installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option }}"
@@ -137,6 +125,12 @@
   command: "{{ installer_command }}"
   become: yes
   become_user: "{{ oracle_user }}"
+  environment:
+    CV_ASSUME_DISTID: OEL7
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version >= '8'
+    - (oracle_ver_base | float) <= 19.3
   register: install_rac_db
   failed_when:
     - "'Successfully Setup Software' not in install_rac_db.stdout"

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -94,18 +94,6 @@
     - "{{ osw_files }}"
   tags: rac-gi,sw-unzip
 
-- name: rac-gi-install | Patch OL8 CVU issue MOS note 2878100.1
-  become: yes
-  become_user: "{{ grid_user }}"
-  lineinfile:
-    path: "{{ install_unzip_path }}/cv/admin/cvu_config"
-    regexp: "^CV_ASSUME_DISTID"
-    line: "CV_ASSUME_DISTID=OEL7.8"
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - oracle_ver_base == '19.3'
-
 - include_role:
     name: common
     tasks_from: populate-asm-disks.yml
@@ -176,7 +164,7 @@
 
 - name: rac-gi-install | Set installer command
   set_fact:
-    installer_command: "{{ grid_home }}/gridSetup.sh -silent -responseFile {{ install_unzip_path }}/gridsetup.rsp {{ has_patch|default('') }} {{ rel_patch|default('') }} {{ mgmt_option|default('') }} {{ prereq_option }}"
+    installer_command: "{{ grid_home }}/gridSetup.sh -silent -responseFile {{ install_unzip_path }}/gridsetup.rsp {{ has_patch | default('') }} {{ rel_patch | default('') }} {{ mgmt_option | default('') }} {{ prereq_option }}"
   tags: rac-gi,rac-gi-install
 
 - name: rac-gi-install | Information
@@ -189,6 +177,10 @@
   become: yes
   become_user: "{{ grid_user }}"
   register: install_rac_gi
+  environment: 
+    CV_ASSUME_DISTID: OEL7  
+  when:
+    - (oracle_ver_base | float) <= 19.3
   failed_when:
     - "'Successfully Setup Software' not in install_rac_gi.stdout"
     - "install_rac_gi.rc not in [0,6,250]"

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -172,15 +172,22 @@
     msg: "Using installer cmd: {{ installer_command }}"
   tags: rac-gi,rac-gi-install
 
+
+- name: rac-gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+  set_fact:
+    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
+                           and (ansible_distribution_major_version | int) >= 8
+                           and (oracle_ver_base | float) <= 19.3
+                           else '' }}"
+  tags: rac-gi,rac-gi-install
+
 - name: rac-gi-install | Run installer
   command: "{{ installer_command }}"
   become: yes
   become_user: "{{ grid_user }}"
   register: install_rac_gi
   environment: 
-    CV_ASSUME_DISTID: OEL7  
-  when:
-    - (oracle_ver_base | float) <= 19.3
+    CV_ASSUME_DISTID: "{{ cv_distid }}"
   failed_when:
     - "'Successfully Setup Software' not in install_rac_gi.stdout"
     - "install_rac_gi.rc not in [0,6,250]"

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -188,9 +188,9 @@
   register: install_rac_gi
   environment: 
     CV_ASSUME_DISTID: "{{ cv_distid }}"
-  failed_when:
-    - "'Successfully Setup Software' not in install_rac_gi.stdout"
-    - "install_rac_gi.rc not in [0,6,250]"
+  failed_when: >
+    ('Successfully Setup Software' not in install_rac_gi.stdout) or
+    (install_rac_gi.rc not in [0,6,250])
   tags: rac-gi,rac-gi-install
 
 - name: rac-gi-install | Installer output

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -173,7 +173,7 @@
   tags: rac-gi,rac-gi-install
 
 
-- name: rac-gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+- name: rac-gi-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 # MOS Note 2878100.1
   set_fact:
     cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
                            and (ansible_distribution_major_version | int) >= 8

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -97,45 +97,39 @@
   become_user: "{{ oracle_user }}"
   tags: rdbms-setup,update-opatch-db
 
-- name: rdbms-install | Patch OL8 CVU issue MOS note 2878100.1
-  become: yes
-  become_user: "{{ oracle_user }}"
-  lineinfile:
-    path: "{{ oracle_home }}/cv/admin/cvu_config"
-    regexp: "^CV_ASSUME_DISTID"
-    line: "CV_ASSUME_DISTID=OEL7.8"
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - oracle_ver_base == '19.3'
-
-- name: rdbms-install | Set installer command
+- name: rdbms-install | Set DB installer command
   set_fact:
-    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ swlib_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option }}"
+    db_installer_cmd: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ swlib_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option | default('') }}"
   tags: rdbms-setup
 
 - name: rdbms-install | Information
   debug:
-    msg: "Using installer cmd: {{ installer_command }}"
+    msg: "Using installer cmd: {{ db_installer_cmd }}"
   tags: rdbms-setup
 
-- name: rdbms-install | Run runInstaller
+- name: rdbms-install | Run DB installer
   become: yes
   become_user: "{{ oracle_user }}"
-  command: "{{ installer_command }}"
-  register: install_db_software
-  failed_when: "('Successfully Setup Software' not in install_db_software.stdout) or
-                (install_db_software.rc not in [0,6,250])"
-  tags: rdbms-setup
+  command: "{{ db_installer_cmd }}"
+  environment:
+    CV_ASSUME_DISTID: OEL7
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version >= '8'
+    - (oracle_ver_base | float) <= 19.3
+  register: db_install_result
+  failed_when:
+    - "'Successfully Setup Software' not in db_install_result.stdout"
+    - "db_install_result.rc not in [0,6,250]"
+  tags: rdbms-install
 
 - name: rdbms-install | runInstaller output
   debug:
     msg:
-      - "{{ install_db_software.cmd }}"
-      - "{{ install_db_software.stdout_lines }}"
-    #verbosity: 1
+      - "{{ db_install_result.cmd }}"
+      - "{{ db_install_result.stdout_lines }}"
   tags: rdbms-setup
-
+      
 - name: rdbms-install | Apply one-off and OJVM patches
   become: yes
   become_user: "{{ oracle_user }}"
@@ -166,14 +160,14 @@
   become_user: root
   command: "{{ oracle_base }}/../oraInventory/orainstRoot.sh"
   ignore_errors: yes
-  when: "'skipped' not in install_db_software.stdout"
+  when: "'skipped' not in db_install_result.stdout"
   tags: rdbms-setup
 
 - name: rdbms-install | Run script root.sh
   become: yes
   become_user: root
   command: "{{ oracle_home }}/root.sh"
-  when: "'skipped' not in install_db_software.stdout"
+  when: "'skipped' not in db_install_result.stdout"
   tags: rdbms-setup
 
 - name: rdbms-install | Complete plugin configuration
@@ -183,6 +177,6 @@
   ignore_errors: yes
   register: install_db_plugins
   when: oracle_ver not in ['11.2.0.4.0','12.1.0.2.0']
-  failed_when: "(install_db_plugins.rc not in [0,6]) and
+  failed_when: "(install_db_plugins.rc not in [0,6,250]) and
                 ('The Installer has detected that there are no config tools to execute for the specified Oracle home' not in install_db_plugins.stdout)"
   tags: rdbms-setup

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -122,9 +122,9 @@
   environment:
     CV_ASSUME_DISTID: "{{ cv_distid }}"
   register: db_install_result
-  failed_when:
-    - "'Successfully Setup Software' not in db_install_result.stdout"
-    - "db_install_result.rc not in [0,6,250]"
+  failed_when: >
+    ('Successfully Setup Software' not in db_install_result.stdout) or
+    (db_install_result.rc not in [0,6,250])
   tags: rdbms-install
 
 - name: rdbms-install | runInstaller output

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -107,7 +107,7 @@
     msg: "Using installer cmd: {{ db_installer_cmd }}"
   tags: rdbms-setup
 
-- name: rdbms-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+- name: rdbms-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 # MOS Note 2878100.1
   set_fact:
     cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
                            and (ansible_distribution_major_version | int) >= 8

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -107,16 +107,20 @@
     msg: "Using installer cmd: {{ db_installer_cmd }}"
   tags: rdbms-setup
 
+- name: rdbms-install | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8 (MOS Note: 2878100.1)
+  set_fact:
+    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
+                           and (ansible_distribution_major_version | int) >= 8
+                           and (oracle_ver_base | float) <= 19.3
+                           else '' }}"
+  tags: rdbms-setup
+
 - name: rdbms-install | Run DB installer
   become: yes
   become_user: "{{ oracle_user }}"
   command: "{{ db_installer_cmd }}"
   environment:
-    CV_ASSUME_DISTID: OEL7
-  when:
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version >= '8'
-    - (oracle_ver_base | float) <= 19.3
+    CV_ASSUME_DISTID: "{{ cv_distid }}"
   register: db_install_result
   failed_when:
     - "'Successfully Setup Software' not in db_install_result.stdout"

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -133,7 +133,7 @@
       - "{{ db_install_result.cmd }}"
       - "{{ db_install_result.stdout_lines }}"
   tags: rdbms-setup
-      
+
 - name: rdbms-install | Apply one-off and OJVM patches
   become: yes
   become_user: "{{ oracle_user }}"


### PR DESCRIPTION
## Change Description:

Installation of Oracle versions 18c and below is not officially supported on RHEL/OL 8. 

## Solution Overview:

This commit introduces an environment variable, 'CV_ASSUME_DISTID,' for both grid and RDBMS installation tasks in Ansible playbooks. If the Oracle version is 18.0 or lower, the variable is set to 'OEL7', ensuring compatibility during the installation process. This change enhances the installation scripts by addressing potential issues related to Oracle version handling.

Additionally, this change adds one more exit code, which is NOT treated as a failure - code 250. The return code indicates that The setup ended in a state that indicates “no further configuration required.” 

## Test command

```bash
./install-oracle.sh \
    --ora-swlib-bucket 
    --backup-dest +RECO \
    --ora-version 18.0.0.0.0 \
    --ora-edition EE \
    --ora-swlib-type gcs \
    --instance-hostname gorjantodorovski-db-rhel8-0ayg \
    --instance-ip-addr 10.2.80.96 \
    --ora-data-mounts data_mounts_config.json \
    --ora-asm-disks asm_disk_config.json \
    --allow-install-on-vm
```