### PR TITLE
Add functionality for removing Free Edition RPM based installs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,11 +1,12 @@
 [defaults]
-inventory			= ./inventory
-deprecation_warnings		= False
-become_method			= sudo
-retry_files_enabled		= False
-#display_skipped_hosts		= False
-#stdout_callback		= debug
-#stderr_callback		= debug
-#allow_world_readable_tmpfiles	= true
-#remote_tmp			= /tmp/ansible
-interpreter_python		= auto_legacy_silent
+inventory                       = ./inventory
+deprecation_warnings            = False
+become_method                   = sudo
+retry_files_enabled             = False
+#display_skipped_hosts          = False
+#stdout_callback                = debug
+#stderr_callback                = debug
+#allow_world_readable_tmpfiles  = true
+#remote_tmp                     = /tmp/ansible
+interpreter_python              = auto_legacy_silent
+command_warnings                = False

--- a/roles/brute-ora-cleanup/README.md
+++ b/roles/brute-ora-cleanup/README.md
@@ -29,8 +29,3 @@ Sample brute force clean-up for Free Edition using the included shell script:
   --inventory-file inventory_files/inventory_10.2.80.54_FREE \
   --yes-i-am-sure
 ```
-
-## Items not covered
-
-- Removal of ASMlib packages (if installed)
-- Removal of udev rules (if configured)

--- a/roles/brute-ora-cleanup/README.md
+++ b/roles/brute-ora-cleanup/README.md
@@ -1,13 +1,33 @@
 # Oracle Brute Force Clean-up
 
-_Caution - destructive tasks - will permanentally erase software_
+_Caution - destructive tasks - will permanently erase software_
 
 Role to do a brute force removal of all Oracle software on server. Run with Oracle/GI services up.
+
+Objective is to return the target server to the pre-Oracle software installation state. Consequently all files, directories, and databases are permanently removed.
 
 Sample execution:
 
 ```bash
 ansible-playbook brute-cleanup.yml --extra-vars "oracle_ver=11.2.0.4.0"
+```
+
+## Free Edition Clean-up
+
+Oracle Database Free Edition is exclusively an RPM installation and supports numerous [versions](../../docs/user-guide.md#free-edition-version-details) without patches.
+
+Therefore, to run a brute force removal of an Oracle Database Free Edition installation, specify the appropriate version with the `--ora-version` command line argument, and also include `--ora-edition FREE` to differentiate from a commercial edition installation of the same version.
+
+A brute force cleanup of a Free Edition database will attempt to first remove the existing database/listener and uninstall the software cleanly. Should that process fail or be unable to run due to a broken installation, forceful removal steps will be taken to ensure that the target server is left in an clean state.
+
+Sample brute force clean-up for Free Edition using the included shell script:
+
+```bash
+./cleanup-oracle.sh \
+  --ora-edition FREE \
+  --ora-version 23.6.0.24.10 \
+  --inventory-file inventory_files/inventory_10.2.80.54_FREE \
+  --yes-i-am-sure
 ```
 
 ## Items not covered

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -14,17 +14,16 @@
 
 ---
 - name: Shut down RAC clusterware
-  # Regrettably we can't use ansible's service module, as Oracle's initscripts don't report status
-  shell:
-    service ohasd stop
+  # Regrettably we can't use ansible's service module, as Oracle's init scripts don't report status
+  shell: service ohasd stop
   args:
     warn: false
-  become: yes
-  register: srvice_stop
+  become: true
+  register: service_stop
   ignore_errors: true
   when: cluster_name is defined
 
-- name: Deconfigure RAC CRS
+- name: De-configure RAC CRS
   shell: |
     ( $ORACLE_HOME/crs/install/rootcrs.sh -deconfig -force ) || true
   environment:
@@ -32,8 +31,8 @@
     PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
   register: has_deconfig
-  ignore_errors: yes
-  become: yes
+  ignore_errors: true
+  become: true
   become_user: "{{ grid_user }}"
   when: cluster_name is defined
 
@@ -47,29 +46,146 @@
     PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
     ORACLE_SID: "{{ asm_sid }}"
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
-  register: srvice_stop
-  ignore_errors: yes
-  become: yes
+  register: service_stop
+  ignore_errors: true
+  become: true
   become_user: "{{ grid_user }}"
-  when: cluster_name is not defined
+  when:
+    - cluster_name is not defined
+    - not free_edition
 
-- name: Deconfigure CRS (non-RAC)
+- name: Free Edition cleanup steps
+  block:
+    - include_role:
+        name: common
+        tasks_from: populate-vars.yml
+
+    - name: Stat Free Edition script
+      stat:
+        path: "/etc/init.d/oracle-free-{{ free_edition_name }}"
+      register: free_script_file_stat
+
+    - name: Clean removal of database and listener
+      shell:
+        cmd: "/etc/init.d/oracle-free-{{ free_edition_name }} delete"
+      when:
+        - free_script_file_stat.stat.exists
+        - free_script_file_stat.stat.executable
+
+    - name: Capture installed Free Edition related systemd services
+      shell:
+        cmd: |
+          set -o pipefail
+          systemctl list-units --type=service --all \
+            | grep -Ei '{{ systemd_service_name }}|oracle-database-preinstall-{{ free_edition_name }}-firstboot' \
+            | awk '{ print $1 }' \
+            | grep service \
+            || true
+      register: free_edition_systemd_services
+      changed_when:
+        - not free_edition_systemd_services.failed
+        - free_edition_systemd_services.stdout is defined
+        - free_edition_systemd_services.stdout | length > 0
+
+    - name: Stop and disable systemd services for Free Edition
+      systemd:
+        name: "{{ item }}"
+        state: stopped
+        enabled: false
+        daemon_reload: true
+      register: systemd_stop
+      with_items: "{{ free_edition_systemd_services.stdout_lines }}"
+      when:
+        - free_edition_systemd_services.changed
+      notify:
+        - Run systemctl daemon-reload
+        - Reset failed systemd services
+
+    - name: Capture installed Free Edition related RPM packages
+      shell:
+        cmd: "rpm -qa | grep -i 'oracle-database' || true"
+      register: free_edition_rpm_packages
+      changed_when:
+        - not free_edition_rpm_packages.failed
+        - free_edition_rpm_packages.stdout is defined
+        - free_edition_rpm_packages.stdout | length > 0
+
+    - name: Remove found RPMs via DNF (and run scriptlets)
+      dnf:
+        name: "{{ item }}"
+        state: absent
+        autoremove: true
+      register: dnf_remove
+      with_items: "{{ free_edition_rpm_packages.stdout_lines }}"
+      when:
+        - free_edition_rpm_packages.changed
+
+    - name: Force remove broken packages (if dnf module uninstall fails)
+      shell:
+        cmd: "rpm --erase --noscripts --nodeps {{ item }}"
+      with_items: "{{ free_edition_rpm_packages.stdout_lines }}"
+      when:
+        - dnf_remove.failed is defined
+        - dnf_remove.failed
+
+    - name: Run "Preinstall settings" script with the uninstall argument
+      shell:
+        cmd: "/usr/bin/oracle-database-preinstall-{{ free_edition_name }}-verify -u 2> /dev/null 1>&2;"
+      when:
+        - dnf_remove.failed is defined
+        - dnf_remove.failed
+
+    - name: Remove any remaining Free Edition specific files and directories
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - "/etc/rc.d/init.d/oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc2.d/K05oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc2.d/S80oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc3.d/K05oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc3.d/S80oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc4.d/K05oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc4.d/S80oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc5.d/K05oracle-free-{{ free_edition_name }}"
+        - "/etc/rc.d/rc5.d/S80oracle-free-{{ free_edition_name }}"
+        - "/etc/security/limits.d/oracle-database-preinstall-{{ free_edition_name }}.conf"
+        - "/etc/sysconfig/oracle-database-preinstall-{{ free_edition_name }}"
+        - "/etc/sysconfig/oracle-free-{{ free_edition_name }}.conf"
+        - "/etc/systemd/system/oracle-database-preinstall-{{ free_edition_name }}-firstboot.service"
+        - "/opt/oracle"
+        - "/opt/ORCLfmap"
+        - "/usr/bin/oracle-database-preinstall-{{ free_edition_name }}-verify"
+        - "/usr/share/doc/oracle-free-{{ free_edition_name }}"
+        - "/usr/share/licenses/oracle-database-preinstall-{{ free_edition_name }}"
+        - "/var/log/oracle-database-free-{{ free_edition_name }}"
+        - "/var/log/oracle-database-preinstall-{{ free_edition_name }}"
+
+  ignore_errors: true
+  become: true
+  become_user: root
+  when: free_edition
+
+- name: De-configure CRS (non-RAC)
   command: "{{ grid_home }}/perl/bin/perl -I {{ grid_home }}/perl/lib -I {{ grid_home }}/crs/install {{ grid_home }}/crs/install/roothas.pl -deconfig -force -verbose"
   register: has_deconfig
-  ignore_errors: yes
-  become: yes
+  ignore_errors: true
+  become: true
   become_user: root
-  when: cluster_name is not defined
-  
+  when:
+    - cluster_name is not defined
+    - not free_edition
+
 - name: Uninstall TFA service
   command: "{{ grid_home }}/bin/tfactl uninstall -local -silent"
   environment:
     PATH: "{{ grid_home }}/perl/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
     PERL5LIB: "{{ grid_home }}/perl/lib"
   register: uninstall_tfa
-  ignore_errors: yes
-  become: yes
+  ignore_errors: true
+  become: true
   become_user: root
+  when: not free_edition
 
 - name: Kill (SIGTERM) any remaining Oracle processes
   command: "pkill -f {{ item }}"
@@ -84,15 +200,15 @@
     - '\\+ASM'
     - /grid/bin
     - /grid/jdk
-    - "-u {{ grid_user }}"
     - "-u {{ oracle_user }}"
-  ignore_errors: yes
+    - "{% if free_edition %}[]{% else %}-u {{ grid_user }}{% endif %}"
+  ignore_errors: true
   register: kill_procs
   changed_when: kill_procs.rc == 0
   failed_when:
     - kill_procs.rc != 0
     - kill_procs.rc != 1
-  become: yes
+  become: true
   become_user: root
 
 - name: Wait for processes to die (10 seconds)
@@ -112,19 +228,19 @@
     - '\\+ASM'
     - /grid/bin
     - /grid/jdk
-    - "-u {{ grid_user }}"
     - "-u {{ oracle_user }}"
-  ignore_errors: yes
+    - "{% if free_edition %}[]{% else %}-u {{ grid_user }}{% endif %}"
+  ignore_errors: true
   register: kill_procs
   changed_when: kill_procs.rc == 0
   failed_when:
     - kill_procs.rc != 0
     - kill_procs.rc != 1
-  become: yes
+  become: true
   become_user: root
 
 - name: Remove directories and files
-  become: yes
+  become: true
   become_user: root
   file:
     path: "{{ item }}"
@@ -136,36 +252,36 @@
     - "{{ grid_home }}"
     - "{{ oracle_root }}"
     - "{{ swlib_unzip_path }}"
-    - /usr/tmp/.oracle
-    - /var/tmp/.oracle
-    - /tmp/.oracle
-    - /tmp/srvctl
-    - /etc/oratab
-    - /etc/oragchomelist
-    - /etc/oraInst.loc
-    - /usr/local/bin/dbhome
-    - /usr/local/bin/oraenv
-    - /usr/local/bin/coraenv
-    - /etc/init.d/acfssihamount
-    - /etc/init.d/ohasd
-    - /etc/init.d/init.ohasd
-    - /etc/init.d/init.orachkscheduler
-    - /etc/init.d/init.tfa
-    - /etc/oracle
-    - /etc/sysconfig/oracleasm-update
-    - /etc/sysconfig/oracleasm.rpmsave
-    - /etc/sysconfig/oracledrivers.conf
-    - /etc/systemd/system/oracle-ohasd.service
-    - /etc/systemd/system/graphical.target.wants/oracle-ohasd.service
-    - /etc/systemd/system/multi-user.target.wants/oracle-ohasd.service
-    - /etc/systemd/system/multi-user.target.wants/oracleasm.service
-    - /var/log/oracleasm
-    - /var/log/oracleohasd
+    - "/usr/tmp/.oracle"
+    - "/var/tmp/.oracle"
+    - "/tmp/.oracle"
+    - "/tmp/srvctl"
+    - "/etc/oratab"
+    - "/etc/oragchomelist"
+    - "/etc/oraInst.loc"
+    - "/usr/local/bin/dbhome"
+    - "/usr/local/bin/oraenv"
+    - "/usr/local/bin/coraenv"
+    - "/etc/init.d/acfssihamount"
+    - "/etc/init.d/ohasd"
+    - "/etc/init.d/init.ohasd"
+    - "/etc/init.d/init.orachkscheduler"
+    - "/etc/init.d/init.tfa"
+    - "/etc/oracle"
+    - "/etc/sysconfig/oracleasm-update"
+    - "/etc/sysconfig/oracleasm.rpmsave"
+    - "/etc/sysconfig/oracledrivers.conf"
+    - "/etc/systemd/system/oracle-ohasd.service"
+    - "/etc/systemd/system/graphical.target.wants/oracle-ohasd.service"
+    - "/etc/systemd/system/multi-user.target.wants/oracle-ohasd.service"
+    - "/etc/systemd/system/multi-user.target.wants/oracleasm.service"
+    - "/var/log/oracleasm"
+    - "/var/log/oracleohasd"
   ignore_errors: true
   register: remove_files
 
 - name: Clean up shared memory segments
-  become: yes
+  become: true
   become_user: root
   shell: "ipcs -m | awk '/{{ item }}/ {print $2}' | xargs -r -L1 ipcrm -m"
   with_items:
@@ -173,7 +289,7 @@
     - "{{ oracle_user }}"
 
 - name: Clean up semaphores
-  become: yes
+  become: true
   become_user: root
   shell: "ipcs -s | awk '/{{ item }}/ {print $2}' | xargs -r -L1 ipcrm -s"
   with_items:
@@ -189,7 +305,7 @@
   register: tmp_dirs
 
 - name: Remove any found /tmp/CVU dirs
-  become: yes
+  become: true
   become_user: root
   file:
     path: "{{ item.path }}"
@@ -197,7 +313,7 @@
   with_items: "{{ tmp_dirs.files }}"
 
 - name: (asmlib) Delete asmlib managed disks
-  become: yes
+  become: true
   become_user: root
   command: "/usr/sbin/oracleasm deletedisk {{ item.1.name }}"
   with_subelements:
@@ -208,10 +324,10 @@
   ignore_errors: true
 
 - name: (asmlib) remove oracleasm packages
-  become: yes
+  become: true
   become_user: root
   yum:
-    name: '*oracleasm*'
+    name: "*oracleasm*"
     state: absent
     lock_timeout: 180
   when: asm_disk_management == "asmlib"
@@ -225,8 +341,7 @@
   shell: |
     umount -f -l "{{ item.mount_point }}"
   ignore_errors: true
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
+  with_items: "{{ oracle_user_data_mounts }}"
 
 - name: Remove Oracle user data devices from fstab
   mount:
@@ -238,38 +353,33 @@
   failed_when:
     - fstab_result is failed
     - "'Directory not empty' not in fstab_result.module_stdout"
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
-  when: 
-    - item.first_partition_id is defined
-    
+  with_items: "{{ oracle_user_data_mounts }}"
+  when: item.first_partition_id is defined
+
 - name: Remove magic strings from Oracle user data partitions
-  become: yes
+  become: true
   become_user: root
   command: "wipefs --all --force {{ item.first_partition_id }}"
-  when: 
+  when:
     - "'mapper' not in item.blk_device"
     - item.first_partition_id is defined
   ignore_errors: true
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
+  with_items: "{{ oracle_user_data_mounts }}"
 
 - name: Remove magic strings from Oracle user data disks
-  become: yes
+  become: true
   become_user: root
   command: "wipefs --all --force {{ item.blk_device }}"
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
+  with_items: "{{ oracle_user_data_mounts }}"
 
 - name: Reload partition table for user data disks
-  become: yes
+  become: true
   become_user: root
   command: "partprobe {{ item.blk_device }}"
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
+  with_items: "{{ oracle_user_data_mounts }}"
 
 - name: Zero-out header in ASM disks partitions
-  become: yes
+  become: true
   become_user: root
   command: "dd if=/dev/zero of={{ item.1.blk_device }} bs=1M count=100"
   with_subelements:
@@ -296,9 +406,9 @@
     - name: Remove fstab entry
       lineinfile:
         path: /etc/fstab
-        regexp: '^{{ swap_blk_device }}'
+        regexp: "^{{ swap_blk_device }}"
         state: absent
-  become: yes
+  become: true
   when:
     - swap_blk_device is defined
     - swap_partition_id is defined
@@ -307,11 +417,10 @@
   tags: remove-swap
 
 - name: Refresh kernel partition table view
-  become: yes
+  become: true
   become_user: root
   command: "blockdev --rereadpt {{ item.blk_device }}"
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
+  with_items: "{{ oracle_user_data_mounts }}"
   when: "'mapper' not in item.blk_device"
   ignore_errors: true
 
@@ -328,7 +437,7 @@
   tags: asm-disks
 
 - name: (udev) remove oracle udev rules
-  become: yes
+  become: true
   become_user: root
   file:
     path: /etc/udev/rules.d/99-oracle-asmdevices.rules
@@ -336,29 +445,29 @@
   when: asm_disk_management == "udev"
 
 - name: (udev) Reload rules
-  become: yes
+  become: true
   become_user: root
   shell: ( /sbin/udevadm control --reload-rules && /sbin/udevadm trigger )
   when: asm_disk_management == "udev"
 
 - name: Remove oracle kernel modules
-  become: yes
+  become: true
   become_user: root
   shell: awk '/^oracle/ {print $1}' /proc/modules | sudo xargs -r modprobe -r
 
 - name: Remove users
-  become: yes
+  become: true
   become_user: root
   user:
     name: "{{ item.name }}"
     state: absent
-    remove: yes
-    force: yes
+    remove: true
+    force: true
   with_items: "{{ oracle_users }}"
   register: remove_users
 
 - name: Remove groups
-  become: yes
+  become: true
   become_user: root
   group:
     name: "{{ item.group }}"
@@ -368,10 +477,10 @@
     - "{{ asm_groups }}"
   register: remove_groups
 
-- name: Results prior to server reboot
+- name: Results prior captured outputs
   debug:
     msg:
-      - "{{ srvice_stop }}"
+      - "{{ service_stop }}"
       - "{{ kill_procs }}"
       - "{{ has_deconfig }}"
       - "{{ remove_files }}"
@@ -381,17 +490,3 @@
       - "{{ remove_oracleasm }}"
       - "{{ zero_disks }}"
     verbosity: 1
-
-- name: Server reboot
-  become: yes
-  become_user: root
-  reboot:
-  register: server_reboot
-  when: "('virtualbox' in ansible_virtualization_type)"
-
-- name: Re-mount swlib
-  become: yes
-  become_user: root
-  # Not using the Ansible mount module as this is a temporary mount
-  command: "mount -t vboxsf swlib {{ swlib_path }}"
-  when: "('virtualbox' in ansible_virtualization_type)"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Run systemctl daemon-reload
+  command: systemctl daemon-reload
+  become: true
+  become_user: root
+
+- name: Reset failed systemd services
+  command: systemctl reset-failed
+  become: true
+  become_user: root


### PR DESCRIPTION
## Change Description:

Add Oracle Database Free Edition (and notably RPM based installation) cleanup and remove ability to the brute force cleanup workflow.

## Solution Overview:

Since Oracle Database Free Editions are RPM based installations, significant changes to the the brute force cleanup process is required. Including:

- Changing the `cleanup-oracle.sh` shell script to accept the `ORA_EDITION` environment variable or the `--ora-edition` command line switch to specify that the cleanup is for a Free Edition installation.
  - In the future, there is the possibility that a specific Oracle version may be available in both Free and commercial (SE2/EE) editions and therefore relying on the version alone is not sufficient.
- Major additions to the `brute-force-cleanup` role to perform the required steps to remove the RPM, the systemd services, and related files unique to Free Edition.
  - Due to the relatively deep linking of RPM scriplet activities and service files the overall process is to try removing & uninstalling using the standard process and then reverting to more direct removal/deletion commands if necessary (which may be necessary in the case of a broken or corrupted installation).
  - Since the new tasks performing a systemd reload and reset are generic with a high probability of re-usability by other tasks (possibly in the future with additional toolkit enhancements) or Oracle technology changes, these tasks are added to the `common` role as handlers.

Additional changes include:

- General Ansible fixes and enhancements to the `roles/brute-ora-cleanup/tasks/main.yml` task file to align with best practices including: truthy fixes, string quoting, white-space normalization, and task optimizations and idempotency enhancements as possible in YAML and shell scripts.
- Updated `ansible.cfg` to replace tabs with spaces and include `command_warnings = False` to suppress the Ansible 2.9 warnings on using `rpm` through the `shell`/`cmd` module.  This does not suppress other warnings such as when SELinux is disabled.

## Test Commands:

### Test Prep:

Required `data_mounts_config.json` file content:

```json
[
  {
    "purpose": "software",
    "blk_device": "/dev/disk/by-id/google-oracle-disk-1",
    "name": "u01",
    "fstype": "xfs",
    "mount_point": "/u01",
    "mount_opts": "nofail"
  }
]
```

Enter the appropriate IP address for the target database server:

```bash
export INSTANCE_IP_ADDR=10.2.80.16
```

Install the "latest" version of 23ai Free Edition by default (i.e. by not explicitly stating a specific version):

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition \
  --backup-dest /opt/oracle/fast_recovery_area/FREE \
  --allow-install-on-vm
```

### Test 1: Cleanup against a fully installed, configured, and operational target:

Run cleanup command:

```bash
./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.6.0.24.10 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --yes-i-am-sure
```

Steps to test resulting target server:

```bash
hostname -I
find /etc | grep ora | grep -Eiv 'linux|fedora|oracle-release|oracle.com|orabackup|RPM-GPG-KEY-oracle'
find /etc | grep -Ei 'database|23c|23ai'
find /usr | grep -Ei 'database|23c|23ai' | grep -Eiv 'google|gcloud|cpython|mime|pip|build-id|firmware|23com'
find /opt | grep -Ei 'database|23c|23ai'
systemctl | grep -Ei 'oracle|free'
grep oracle /etc/passwd
ps -ef | grep oracle
```

### Test 2: Re-execution of cleanup against an already cleaned up target:

Run cleanup command:

```bash
./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.6.0.24.10 \
  --inventory-file inventory_files/inventory_10.2.80.63_FREE \
  --yes-i-am-sure
```

Steps to test resulting target server:

```bash
hostname -I
find /etc | grep ora | grep -Eiv 'linux|fedora|oracle-release|oracle.com|orabackup|RPM-GPG-KEY-oracle'
find /etc | grep -Ei 'database|23c|23ai'
find /usr | grep -Ei 'database|23c|23ai' | grep -Eiv 'google|gcloud|cpython|mime|pip'
find /opt | grep -Ei 'database|23c|23ai'
systemctl | grep -Ei 'oracle|free'
grep oracle /etc/passwd
ps -ef | grep oracle
```

## Expected Results:

- Initial run removes all traces of the Oracle database and software from the target server.
- When run against an installed/configured/running database target, all tasks succeed or are skipped - none failed/ignored.
- New steps/tasks are fully idempotent regardless of state of the target database server - no failed/ignored Free Edition specific tasks.
