### PR TITLE
Cleanup process enhancement: improved if-statement to instead check on `role_separation`

### DIFF
--- a/cleanup-oracle.sh
+++ b/cleanup-oracle.sh
@@ -127,9 +127,11 @@ done
 
 shopt -s nocasematch
 
-# Oracle Database free edition parameter overrides
-if [[ "${ORA_EDITION}" = "FREE" && ! "${ORA_VERSION}" =~ ^23\. ]]; then
-    ORA_VERSION="23.0.0.0.0"
+# Parameter defaults and changes required for Free Edition
+# (including unsupported features such as role_separation)
+if [[ "${ORA_EDITION}" = "FREE" ]]; then
+    ORA_ROLE_SEPARATION=FALSE
+    [[ ! "${ORA_VERSION}" =~ ^23\. ]] && ORA_VERSION="23.0.0.0.0"
 fi
 
 # Mandatory options

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -201,7 +201,7 @@
     - /grid/bin
     - /grid/jdk
     - "-u {{ oracle_user }}"
-    - "{% if free_edition %}[]{% else %}-u {{ grid_user }}{% endif %}"
+    - "{% if role_separation | bool %}-u {{ grid_user }}{% else %}[]{% endif %}"
   ignore_errors: true
   register: kill_procs
   changed_when: kill_procs.rc == 0
@@ -229,7 +229,7 @@
     - /grid/bin
     - /grid/jdk
     - "-u {{ oracle_user }}"
-    - "{% if free_edition %}[]{% else %}-u {{ grid_user }}{% endif %}"
+    - "{% if role_separation | bool %}-u {{ grid_user }}{% else %}[]{% endif %}"
   ignore_errors: true
   register: kill_procs
   changed_when: kill_procs.rc == 0


### PR DESCRIPTION
Enhancement to base the conditional check on the `role_separation` variable.

Re-tested execution:

- If there is `role_separation == TRUE` then it will `pkill` for both the **oracle** and **grid** users.  When not (including for Free Edition), it will only `pkill` processes by the **oracle** user and therefore avoid unnecessary failed messages due to trying to kill processes for a user that is not applicable to the installation.
