### PR TITLE
Remove duplicate `hugepages` role call from the the `meta/main.yml` file

### DIFF
--- a/roles/ora-host/meta/main.yml
+++ b/roles/ora-host/meta/main.yml
@@ -15,4 +15,3 @@
 ---
 dependencies:
   - role: common
-  - role: hugepages


### PR DESCRIPTION
## Problem Summary:

Playbook `prep-host.yml` has a task that calls several roles including the `hugepages` role:

```yaml
- hosts: dbasm
  become: yes
  become_user: root
  pre_tasks:
    - name: Verify that Ansible on control node meets the version requirements
      assert:
        that: "ansible_version.full is version_compare('2.8', '>=')"
        fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
        success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
  roles:
    - { role: base-provision, tags: base-provision }
    - { role: host-storage, tags: host-storage }
    - { role: ora-host, tags: ora-host }
    - { role: hugepages, tags: hugepages }
```

However, the `ora-host` role, has the `roles/ora-host/meta/main.yml` file:

```yaml
# Copyright 2020 Google LLC
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#      http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

---
dependencies:
  - role: common
  - role: hugepages
```

The key issue is that the `hugepages` role is consequently being executed twice. Further, the current `hugepages` role is noisy (polouting the overall output with numerous `debug` statements without verbosity controls) and inefficient. (The `hugepages` role tasks will be overhauled in a forthcoming separate change.)

The `meta/main.yml` file dependencies are processed first, before the rest of the `ora-host` tasks. However, all of these are server build/prerequisite tasks and kernel huge pages only need to be set before the Oracle software is used, which happens in later playbooks. And therefore, it doesn't matter significantly where the `hugepages` role is called in the `prep-host.yml` playbook. Removing from the `ora-host`'s dependencies list allows alignment with other Ansible role calls in the `prep-host.yml` playbook.  All of which should be revisited in a future change/PR.

Confirmation that this is the only role called twice by playbooks:

```bash
$ grep -r 'role: ' | grep -v common
install-sw.yml:    - role: gi-setup
install-sw.yml:    - role: rdbms-setup
prep-host.yml:    - { role: base-provision, tags: base-provision }
prep-host.yml:    - { role: host-storage, tags: host-storage }
prep-host.yml:    - { role: ora-host, tags: ora-host }
prep-host.yml:    - { role: hugepages, tags: hugepages }
prep-host.yml:    - { role: swlib, tags: swlib }
roles/ora-host/meta/main.yml:  - role: hugepages
```

## Solution Overview:

Remove the second, redundant calling of the `hugepages` role.

Overall host preparation tasks may be revisited and optimized separately and independently of this change.

And similarly, a change to optimize the task file for the `hugepages` role is forthcoming.

## Validation of Change:

Kernel settings in database server before running toolkit (with change implemented):

```bash
$ sysctl -e kernel.sem kernel.shmall kernel.shmmax kernel.shmmni kernel.panic_on_oops kernel.panic fs.file-max fs.aio-max-nr net.ipv4.ip_local_port_range net.core.rmem_default net.core.rmem_max net.core.wmem_default net.core.wmem_max
kernel.sem = 32000      1024000000      500     32000
kernel.shmall = 18446744073692774399
kernel.shmmax = 18446744073692774399
kernel.shmmni = 4096
kernel.panic_on_oops = 1
kernel.panic = 10
fs.file-max = 1501752
fs.aio-max-nr = 65536
net.ipv4.ip_local_port_range = 32768    60999
net.core.rmem_default = 212992
net.core.rmem_max = 212992
net.core.wmem_default = 212992
net.core.wmem_max = 212992
```

Kernel settings in database server after running toolkit (with change implemented):

```bash
$ sysctl -e kernel.sem kernel.shmall kernel.shmmax kernel.shmmni kernel.panic_on_oops kernel.panic fs.file-max fs.aio-max-nr net.ipv4.ip_local_port_range net.core.rmem_default net.core.rmem_max net.core.wmem_default net.core.wmem_max
kernel.sem = 250        32000   100     128
kernel.shmall = 2454068
kernel.shmmax = 10051859251
kernel.shmmni = 4096
kernel.panic_on_oops = 1
kernel.panic = 10
fs.file-max = 6815744
fs.aio-max-nr = 1048576
net.ipv4.ip_local_port_range = 9000     65500
net.core.rmem_default = 262144
net.core.rmem_max = 4194304
net.core.wmem_default = 262144
net.core.wmem_max = 1048586
```

Results show that the kernel parameters are indeed still being adjusted, as would be expected.

Gist files:

- Full log file of test execution (with change in place) showing huge pages related tasks still being changed: [oratk-44: Full test run output](https://gist.github.com/simonpane/b434a0435ba9c98345ff91a8aa6521ca)
- Log file of toolkit prior to change for comparison: [oratk-44: Regression test run output](https://gist.github.com/simonpane/e6df4514271e9b7956bf345e01786a26)
