### PR TITLE
Update and optimize the "Install Oracle required packages" tasks and related lists

### DIFF
--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -34,7 +34,7 @@
   package:
     name: ntp
     state: absent
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   tags: ntp
 
 - name: Remove ntp conf
@@ -59,7 +59,7 @@
   package:
     name: "{{ packages }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: install_os_packages
   tags: os_packages
 

--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -27,13 +27,14 @@
 
 - name: Ensure yum is not running, send Ctrl-C if it is
   shell: pidof -x /usr/bin/yum /bin/yum | xargs -t -r -n 1 kill -INT
+  when: install_os_packages
   tags: os_packages
 
 - name: Remove ntpd package
   package:
     name: ntp
     state: absent
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
   tags: ntp
 
 - name: Remove ntp conf
@@ -58,7 +59,8 @@
   package:
     name: "{{ packages }}"
     state: present
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
+  when: install_os_packages
   tags: os_packages
 
 - name: Add ntp preferred server

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -115,7 +115,7 @@
         name: "{{ item }}"
         state: absent
         autoremove: true
-        lock_timeout: "{{ dnf_lock_timeout }}"
+        lock_timeout: "{{ pkg_mgr_lock_timeout }}"
       register: dnf_remove
       with_items: "{{ free_edition_rpm_packages.stdout_lines }}"
       when:
@@ -330,7 +330,7 @@
   package:
     name: "*oracleasm*"
     state: absent
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: asm_disk_management == "asmlib"
   register: remove_oracleasm
 

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -111,10 +111,11 @@
         - free_edition_rpm_packages.stdout | length > 0
 
     - name: Remove found RPMs via DNF (and run scriptlets)
-      dnf:
+      package:
         name: "{{ item }}"
         state: absent
         autoremove: true
+        lock_timeout: "{{ dnf_lock_timeout }}"
       register: dnf_remove
       with_items: "{{ free_edition_rpm_packages.stdout_lines }}"
       when:
@@ -326,10 +327,10 @@
 - name: (asmlib) remove oracleasm packages
   become: true
   become_user: root
-  yum:
+  package:
     name: "*oracleasm*"
     state: absent
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
   when: asm_disk_management == "asmlib"
   register: remove_oracleasm
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,6 +14,8 @@
 
 ---
 # Variables used by more than one role
+dnf_lock_timeout: 180
+
 oracle_ver_dir: "{% if free_edition %}{% if oracle_ver[:4] == '23.2' or oracle_ver[:4] == '23.3' %}23c{% else %}{{ oracle_ver[:2] }}ai{% endif %}{% else %}{{ oracle_ver[:6] }}{% endif %}"
 oracle_inventory: "{{ oracle_root }}/oraInventory"
 oracle_base: "{% if free_edition %}/opt/oracle{% else %}{{ oracle_root }}/oracle{% endif %}"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,7 +14,7 @@
 
 ---
 # Variables used by more than one role
-dnf_lock_timeout: 180
+pkg_mgr_lock_timeout: 180
 
 oracle_ver_dir: "{% if free_edition %}{% if oracle_ver[:4] == '23.2' or oracle_ver[:4] == '23.3' %}23c{% else %}{{ oracle_ver[:2] }}ai{% endif %}{% else %}{{ oracle_ver[:6] }}{% endif %}"
 oracle_inventory: "{{ oracle_root }}/oraInventory"

--- a/roles/db-backups/tasks/nfs.yml
+++ b/roles/db-backups/tasks/nfs.yml
@@ -16,10 +16,10 @@
 - name: nfs_backups | Install NFS mount utility
   become: true
   become_user: root
-  yum:
+  package:
     name: nfs-utils
     state: present
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
   when: ansible_os_family == "RedHat"
 
 - name: nfs_backups | Ensure rpcbind is running as configured.

--- a/roles/db-backups/tasks/nfs.yml
+++ b/roles/db-backups/tasks/nfs.yml
@@ -19,7 +19,7 @@
   package:
     name: nfs-utils
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: ansible_os_family == "RedHat"
 
 - name: nfs_backups | Ensure rpcbind is running as configured.

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -84,7 +84,7 @@
   package:
     name: "{{ r.files | map(attribute='path') | list }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
     disable_gpg_check: true
   register: cvuqdisk_res
   environment:

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -81,10 +81,10 @@
 - name: gi-install | Install the cvuqdisk RPM
   become: true
   become_user: root
-  yum:
+  package:
     name: "{{ r.files | map(attribute='path') | list }}"
     state: present
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
     disable_gpg_check: true
   register: cvuqdisk_res
   environment:

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -16,195 +16,145 @@
 install_os_packages: true
 disable_firewall: false
 disable_selinux: true
-firewall_service: "{% if ansible_distribution_major_version | int == 6 %}iptables{%elif ansible_distribution_major_version | int >= 7 %}firewalld{% else %}0{% endif %}"
+firewall_service: "{% if ansible_distribution_major_version | int == 6 %}iptables{% elif ansible_distribution_major_version | int >= 7 %}firewalld{% else %}0{% endif %}"
+
+package_repository_files:
+  - "redhat.repo"
+  - "rh-cloud.repo"
+  - "oracle-linux-ol7.repo"
+  - "oracle-linux-ol8.repo"
+  - "oracle-linux-ol9.repo"
 
 oracle_required_rpms:
   - bc
+  - bind-utils
   - binutils
+  - ethtool
+  - firewalld
+  - glibc
+  - glibc-devel
+  - initscripts
+  - ksh
+  - libaio
+  - libaio-devel
+  - libgcc
+  - libstdc++
+  - libstdc++-devel
+  - libXi
+  - libXtst
+  - make
+  - module-init-tools
+  - net-tools
+  - nfs-utils
+  - openssh-clients
+  - pam
+  - perl  # OS perl is required for OJVM patching as per MOS note 2978451.1
+  - procps
+  - psmisc
+  - smartmontools
+  - sysstat
+  - tar
+  - unzip
+  - util-linux-ng
+  - xorg-x11-utils
+  - xorg-x11-xauth
+
+oracle_required_rpms_el7:
   - compat-libcap1
   - compat-libstdc++-33
-  - cpp
   - gcc
   - gcc-c++
-  - glibc-devel
-  - glibc-headers
-  - gssproxy
-  - kernel-headers
-  - keyutils
-  - ksh
-  - libaio-devel
-  - libbasicobjects
-  - libcollection
-  - libdmx
-  - libevent
-  - libICE
-  - libini_config
-  - libmpc
-  - libnfsidmap
-  - libpath_utils
-  - libref_array
-  - libSM
-  - libstdc++-devel
-  - libtirpc
-  - libverto-libevent
-  - libXi
-  - libXinerama
-  - libXmu
-  - libXrandr
-  - libXrender
-  - libXt
-  - libXtst
-  - libXv
-  - libXxf86dga
-  - libXxf86misc
-  - libXxf86vm
-  - mailx
-  - make
-  - mpfr
-  - nfs-utils
-  - perl  # OS perl is required for OJVM patching as per MOS note 2978451.1
-  - psmisc
-  - quota
-  - quota-nls
-  - rpcbind
-  - smartmontools
-  - sysstat
-  - tcp_wrappers
-  - xorg-x11-utils
-  - xorg-x11-xauth
+  - policycoreutils-python
 
 oracle_required_rpms_el8:
-  - bc
-  - binutils
-  - cpp
-  - gcc
-  - gcc-c++
-  - glibc-devel
-  - glibc-headers
-  - gssproxy
-  - kernel-headers
-  - keyutils
-  - ksh
-  - libaio-devel
-  - libbasicobjects
-  - libcollection
-  - libdmx
-  - libevent
-  - libICE
-  - libini_config
-  - libmpc
-  - libnfsidmap
+  - compat-openssl10
+  - elfutils-libelf
+  - fontconfig
+  - libasan
+  - libibverbs
+  - liblsan
   - libnsl
-  - libnsl.i686
-  - libnsl2
-  - libnsl2.i686
-  - libpath_utils
-  - libref_array
-  - libSM
-  - libstdc++-devel
-  - libtirpc
-  - libverto-libevent
-  - libXi
-  - libXinerama
-  - libXmu
-  - libXrandr
+  - librdmacm
+  - libX11
+  - libXau
+  - libxcb
   - libXrender
-  - libXt
-  - libXtst
-  - libXv
-  - libXxf86dga
-  - libXxf86misc
-  - libXxf86vm
-  - mailx
-  - make
-  - mpfr
-  - nfs-utils
-  - psmisc
-  - quota
-  - quota-nls
-  - rpcbind
-  - smartmontools
-  - sysstat
-  - xorg-x11-utils
-  - xorg-x11-xauth
+  - openssl-libs
+  - policycoreutils
+  - policycoreutils-python-utils
 
 oracle_required_rpms_el9:
-  - bc
-  - binutils
-  - cpp
-  - gcc
-  - gcc-c++
-  - glibc-devel
+  - compat-openssl11
+  - elfutils-libelf
+  - fontconfig
   - glibc-headers
-  - gssproxy
-  - kernel-headers
-  - keyutils
-  - ksh
-  - libaio-devel
-  - libbasicobjects
-  - libcollection
-  - libdmx
-  - libevent
-  - libICE
-  - libini_config
-  - libmpc
-  - libnfsidmap
+  - grub2-tools
+  - libasan
+  - libibverbs
+  - liblsan
   - libnsl
-  - libnsl.i686
   - libnsl2
-  - libnsl2.i686
-  - libpath_utils
-  - libref_array
-  - libSM
-  - libstdc++-devel
-  - libtirpc
+  - librdmacm
+  - libvirt-libs
+  - libX11
+  - libXau
+  - libxcb
   - libxcrypt-compat
-  - libXi
-  - libXinerama
-  - libXmu
-  - libXrandr
   - libXrender
-  - libXt
-  - libXtst
-  - libXv
-  - libXxf86dga
-  - libXxf86vm
-  - make
-  - mpfr
-  - nfs-utils
+  - policycoreutils
   - policycoreutils-python-utils
-  - psmisc
-  - quota
-  - quota-nls
-  - rpcbind
-  - smartmontools
-  - sysstat
-  - xorg-x11-utils
-  - xorg-x11-xauth
 
 sysctl_entries:
-  - { name: "fs.aio-max-nr", value: "1048576" }
-  - { name: "fs.file-max", value: "6815744" }
-  - { name: "kernel.panic_on_oops", value: "1" }
-  # - { name: "kernel.shmall", value: "{{ (ansible_memtotal_mb * 1024 * 1024 / 4096 * 0.6) | int }}" }
-  # - { name: "kernel.shmmax", value: "{{ (ansible_memtotal_mb * 1024 * 1024 * 0.6) | int }}" }
-  # - { name: "kernel.shmmni", value: "4096" }
-  - { name: "kernel.sem", value: "250 32000 100 128" }
-  - { name: "net.ipv4.ip_local_port_range", value: "9000 65500" }
-  - { name: "net.core.rmem_default", value: "262144" }
-  - { name: "net.core.rmem_max", value: "4194304" }
-  - { name: "net.core.wmem_default", value: "262144" }
-  - { name: "net.core.wmem_max", value: "1048586" }
+  - name: fs.aio-max-nr
+    value: "1048576"
+  - name: fs.file-max
+    value: "6815744"
+  - name: kernel.panic_on_oops
+    value: "1"
+  # - name: kernel.shmall
+  #   value: "{{ (ansible_memtotal_mb * 1024 * 1024 / 4096 * 0.6) | int }}"
+  # - name: kernel.shmmax
+  #   value: "{{ (ansible_memtotal_mb * 1024 * 1024 * 0.6) | int }}"
+  # - name: kernel.shmmni
+  #   value: "4096"
+  - name: kernel.sem
+    value: "250 32000 100 128"
+  - name: net.ipv4.ip_local_port_range
+    value: "9000 65500"
+  - name: net.core.rmem_default
+    value: "262144"
+  - name: net.core.rmem_max
+    value: "4194304"
+  - name: net.core.wmem_default
+    value: "262144"
+  - name: net.core.wmem_max
+    value: "1048586"
 
 resource_limits:
-  - { name: "nofile", type: "soft", value: "1024" }
-  - { name: "nofile", type: "hard", value: "65536" }
-  - { name: "nproc", type: "soft", value: "2047" }
-  - { name: "nproc", type: "hard", value: "16384" }
-  - { name: "stack", type: "soft", value: "10240" }
-  - { name: "stack", type: "hard", value: "32768" }
-  - { name: "memlock", type: "soft", value: "unlimited" }
-  - { name: "memlock", type: "hard", value: "unlimited" }
+  - name: nofile
+    type: soft
+    value: "1024"
+  - name: nofile
+    type: hard
+    value: "65536"
+  - name: nproc
+    type: soft
+    value: "2047"
+  - name: nproc
+    type: hard
+    value: "16384"
+  - name: stack
+    type: soft
+    value: "10240"
+  - name: stack
+    type: hard
+    value: "32768"
+  - name: memlock
+    type: soft
+    value: "unlimited"
+  - name: memlock
+    type: hard
+    value: "unlimited"
 
 oracleasm_libs:
   - kmod-oracleasm

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -62,12 +62,12 @@
   with_items: "{{ package_repository_files }}"
   tags: os-packages
 
-- name: Build list of found package manager repo files
+- name: Build a list of detected package manager repo files
   set_fact:
     repo_files: "{{ repo_file_check.results | selectattr('stat.exists') | map(attribute='item') | list }}"
   tags: os-packages
 
-- name: List found package manager repo files
+- name: List all detected package manager repo files
   debug:
     var: repo_files
     verbosity: 1

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -17,7 +17,7 @@
   package:
     list: "{{ firewall_service }}"
     disablerepo: "*"
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: disable_firewall|bool and ansible_os_family == 'RedHat'
   tags: firewall
   register: firewall
@@ -77,7 +77,7 @@
   package:
     name: "{{ oracle_required_rpms + oracle_required_rpms_el7 }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
     enablerepo: rhui-rhel-7-server-rhui-optional-rpms
   when:
     - install_os_packages
@@ -90,7 +90,7 @@
   package:
     name: "{{ oracle_required_rpms + oracle_required_rpms_el7 }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
     enablerepo: rhel-7-server-optional-rpms
   when:
     - install_os_packages
@@ -103,7 +103,7 @@
   package:
     name: "{{ oracle_required_rpms + vars['oracle_required_rpms_el' + ansible_distribution_major_version] }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   loop: "{{ repo_files }}"
   when:
     - install_os_packages
@@ -116,7 +116,7 @@
   package:
     name: "{{ oracle_required_rpms + vars['oracle_required_rpms_el' + ansible_distribution_major_version] }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   loop: "{{ repo_files }}"
   when:
     - install_os_packages
@@ -403,7 +403,7 @@
   package:
     name: "{{ oracleasm_libs }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: asm_disk_management == "asmlib"
   tags: oracleasmlib
 

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -14,7 +14,10 @@
 
 ---
 - name: Check if firewall is installed
-  yum: list={{ firewall_service }} disablerepo=*
+  package:
+    list: "{{ firewall_service }}"
+    disablerepo: "*"
+    lock_timeout: "{{ dnf_lock_timeout }}"
   when: disable_firewall|bool and ansible_os_family == 'RedHat'
   tags: firewall
   register: firewall
@@ -52,142 +55,73 @@
     opts: rw,nosuid,nodev
     state: mounted
 
-- name: Stat RHEL base repo
+- name: Check for existing package manager repo files
   stat:
-    path: /etc/yum.repos.d/redhat.repo
-  register: redhat_repo
-
-- name: Stat RHEL7 rhui repo
-  stat:
-    path: /etc/yum.repos.d/rh-cloud.repo
-  register: rh_cloud_repo
-
-- name: Install Oracle required packages (base/non-rhui config) for Marketplace RHEL7
-  yum:
-    name: "{{ oracle_required_rpms }}"
-    state: present
-    lock_timeout: 180
-    enablerepo: rhui-rhel-7-server-rhui-optional-rpms
-  when:
-    - install_os_packages | bool
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version == '7'
-    - redhat_repo.stat.exists | bool
-    - rh_cloud_repo.stat.exists | bool
+    path: "/etc/yum.repos.d/{{ item }}"
+  register: repo_file_check
+  with_items: "{{ package_repository_files }}"
   tags: os-packages
 
-- name: Install Oracle required packages (base/non-rhui config) for RHEL7
-  yum:
-    name: "{{ oracle_required_rpms }}"
+- name: Build list of found package manager repo files
+  set_fact:
+    repo_files: "{{ repo_file_check.results | selectattr('stat.exists') | map(attribute='item') | list }}"
+  tags: os-packages
+
+- name: List found package manager repo files
+  debug:
+    var: repo_files
+    verbosity: 1
+  tags: os-packages
+
+- name: Install Oracle required packages (RHUI/cloud config) for RHEL7
+  package:
+    name: "{{ oracle_required_rpms + oracle_required_rpms_el7 }}"
     state: present
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
+    enablerepo: rhui-rhel-7-server-rhui-optional-rpms
+  when:
+    - install_os_packages
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '7'
+    - "'rh-cloud.repo' in repo_files"
+  tags: os-packages
+
+- name: Install Oracle required packages (base/non-RHUI config) for RHEL7
+  package:
+    name: "{{ oracle_required_rpms + oracle_required_rpms_el7 }}"
+    state: present
+    lock_timeout: "{{ dnf_lock_timeout }}"
     enablerepo: rhel-7-server-optional-rpms
   when:
-    - rh_cloud_repo is not defined
-    - install_os_packages | bool
+    - install_os_packages
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version == '7'
-    - redhat_repo.stat.exists | bool
+    - "'redhat.repo' in repo_files and 'rh-cloud.repo' not in repo_files"
   tags: os-packages
 
-- name: Stat OL7 repo
-  stat:
-    path: /etc/yum.repos.d/oracle-linux-ol7.repo
-  register: oraclelinux_repo
-  when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
-
-- name: Install Oracle required packages (base/non-rhui config) for OEL7
-  yum:
-    name: "{{ oracle_required_rpms }}"
+- name: Install Oracle required packages for RHEL8+
+  package:
+    name: "{{ oracle_required_rpms + vars['oracle_required_rpms_el' + ansible_distribution_major_version] }}"
     state: present
-    lock_timeout: 180
-    enablerepo: ol7_optional_latest
+    lock_timeout: "{{ dnf_lock_timeout }}"
+  loop: "{{ repo_files }}"
   when:
-    - install_os_packages | bool
-    - ansible_distribution == 'OracleLinux'
-    - ansible_distribution_major_version == '7'
-    - oraclelinux_repo.stat.exists | bool
-  tags: os-packages
-
-- name: Stat OL8 repo
-  stat:
-    path: /etc/yum.repos.d/oracle-linux-ol8.repo
-  register: oraclelinux_repo_oel8
-  when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
-
-- name: Stat OL9 repo
-  stat:
-    path: /etc/yum.repos.d/oracle-linux-ol9.repo
-  register: oraclelinux_repo_oel9
-  when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
-
-- name: Install Oracle required packages (base/non-rhui config) for OEL7
-  yum:
-    name: "{{ oracle_required_rpms }}"
-    state: present
-    lock_timeout: 180
-  when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '7'
-    - oraclelinux_repo.stat.exists|bool
-  tags: os-packages
-
-- name: Install Oracle required packages (base/non-rhui config) for RHEL8
-  yum:
-    name: "{{ oracle_required_rpms_el8 }}"
-    state: present
-    lock_timeout: 180
-  when:
-    - install_os_packages|bool and ansible_distribution == 'RedHat' and ansible_distribution_major_version == '8'
-    - redhat_repo.stat.exists|bool or rh_cloud_repo.stat.exists|bool
-  tags: os-packages
-
-- name: Install Oracle required packages (base/non-rhui config) for RHEL9
-  yum:
-    name: "{{ oracle_required_rpms_el9 }}"
-    state: present
-    lock_timeout: 180
-  when:
-    - install_os_packages|bool
+    - install_os_packages
     - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version == '9'
-    - rh_cloud_repo.stat.exists|bool
+    - ansible_distribution_major_version >= '8'
+    - "'redhat.repo' in repo_files or 'rh-cloud.repo' in repo_files"
   tags: os-packages
 
-- name: Install Oracle required packages (base/non-rhui config) for OEL8
-  yum:
-    name: "{{ oracle_required_rpms_el8 }}"
+- name: Install Oracle required packages for Oracle Linux
+  package:
+    name: "{{ oracle_required_rpms + vars['oracle_required_rpms_el' + ansible_distribution_major_version] }}"
     state: present
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
+  loop: "{{ repo_files }}"
   when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '8'
-    - oraclelinux_repo_oel8.stat.exists|bool
-  tags: os-packages
-
-- name: Install Oracle required packages (base/non-rhui config) for OEL9
-  yum:
-    name: "{{ oracle_required_rpms_el9 }}"
-    state: present
-    lock_timeout: 180
-  when:
-    - install_os_packages|bool
+    - install_os_packages
     - ansible_distribution == 'OracleLinux'
-    - ansible_distribution_major_version == '9'
-    - oraclelinux_repo_oel9.stat.exists|bool
-  tags: os-packages
-
-- name: Install Oracle required packages (rhui config)
-  yum:
-    name: "{{ oracle_required_rpms }}"
-    state: present
-    lock_timeout: 180
-    enablerepo: rhui-rhel-7-server-rhui-optional-rpms
-  when:
-    - install_os_packages|bool and ansible_distribution_major_version == '7'
-    - rh_cloud_repo.stat.exists|bool
-    - not redhat_repo.stat.exists|bool or rh_cloud_repo.stat.exists|bool
+    - "('oracle-linux-ol' ~ ansible_distribution_major_version ~ '.repo') in item"
   tags: os-packages
 
 - name: Add OS groups
@@ -466,8 +400,10 @@
   tags: asm-disks
 
 - name: (asmlib) Install Oracle ASM libraries
-  yum:
+  package:
     name: "{{ oracleasm_libs }}"
+    state: present
+    lock_timeout: "{{ dnf_lock_timeout }}"
   when: asm_disk_management == "asmlib"
   tags: oracleasmlib
 

--- a/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
@@ -17,7 +17,7 @@
   package:
     name: "{{ swlib_path }}/{{ item }}"
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
     disable_gpg_check: true
   with_items: "{{ osw.files }}"
   register: rpm_install

--- a/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
@@ -14,9 +14,10 @@
 
 ---
 - name: Install Oracle RPM
-  dnf:
+  package:
     name: "{{ swlib_path }}/{{ item }}"
     state: present
+    lock_timeout: "{{ dnf_lock_timeout }}"
     disable_gpg_check: true
   with_items: "{{ osw.files }}"
   register: rpm_install

--- a/roles/swlib/tasks/gcloud.yml
+++ b/roles/swlib/tasks/gcloud.yml
@@ -28,5 +28,5 @@
   package:
     name: google-cloud-sdk
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: ansible_os_family == "RedHat"

--- a/roles/swlib/tasks/gcloud.yml
+++ b/roles/swlib/tasks/gcloud.yml
@@ -25,8 +25,8 @@
   when: ansible_os_family == "RedHat"
 
 - name: gcloud | Install latest gcloud SDK package
-  yum:
+  package:
     name: google-cloud-sdk
-    state: installed
-    lock_timeout: 180
+    state: present
+    lock_timeout: "{{ dnf_lock_timeout }}"
   when: ansible_os_family == "RedHat"

--- a/roles/swlib/tasks/gcsfuse.yml
+++ b/roles/swlib/tasks/gcsfuse.yml
@@ -19,15 +19,16 @@
 - name: gcsfuse | Install gcsfuse dependencies
   become: true
   become_user: root
-  yum:
+  package:
     name: fuse
+    lock_timeout: "{{ dnf_lock_timeout }}"
 
 - name: gcsfuse | Install gcsfuse
   become: true
   become_user: root
-  yum:
+  package:
     name: "https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v{{ gcsfuse_version }}/gcsfuse-{{ gcsfuse_version }}-1.x86_64.rpm"
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
 
 - name: gcsfuse | Copy service account key with owner and permissions
   copy:

--- a/roles/swlib/tasks/gcsfuse.yml
+++ b/roles/swlib/tasks/gcsfuse.yml
@@ -21,14 +21,14 @@
   become_user: root
   package:
     name: fuse
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
 
 - name: gcsfuse | Install gcsfuse
   become: true
   become_user: root
   package:
     name: "https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v{{ gcsfuse_version }}/gcsfuse-{{ gcsfuse_version }}-1.x86_64.rpm"
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
 
 - name: gcsfuse | Copy service account key with owner and permissions
   copy:

--- a/roles/swlib/tasks/nfs.yml
+++ b/roles/swlib/tasks/nfs.yml
@@ -16,10 +16,10 @@
 - name: nfs | Install NFS mount utility
   become: true
   become_user: root
-  yum:
+  package:
     name: nfs-utils
     state: present
-    lock_timeout: 180
+    lock_timeout: "{{ dnf_lock_timeout }}"
   when: ansible_os_family == "RedHat"
 
 - name: nfs | Ensure rpcbind is running as configured.

--- a/roles/swlib/tasks/nfs.yml
+++ b/roles/swlib/tasks/nfs.yml
@@ -19,7 +19,7 @@
   package:
     name: nfs-utils
     state: present
-    lock_timeout: "{{ dnf_lock_timeout }}"
+    lock_timeout: "{{ pkg_mgr_lock_timeout }}"
   when: ansible_os_family == "RedHat"
 
 - name: nfs | Ensure rpcbind is running as configured.


### PR DESCRIPTION
## Change Overview

Major overhaul of the "Install Oracle required packages" tasks.  Benefits include using fewer, but more sophisticated Ansible tasks, and reduced STDOUT and logfile output.
 
Previously, the toolkit had **five** separate package manager repository (`.repo`) file `stat` operations and a total of **nine** distinct tasks for installing packages in the `ora-host` role alone:

```yaml
- name: Install Oracle required packages (base/non-rhui config) for Marketplace RHEL7
- name: Install Oracle required packages (base/non-rhui config) for RHEL7
- name: Install Oracle required packages (base/non-rhui config) for OEL7
- name: Install Oracle required packages (base/non-rhui config) for OEL7
- name: Install Oracle required packages (base/non-rhui config) for RHEL8
- name: Install Oracle required packages (base/non-rhui config) for RHEL9
- name: Install Oracle required packages (base/non-rhui config) for OEL8
- name: Install Oracle required packages (base/non-rhui config) for OEL9
- name: Install Oracle required packages (rhui config)
```

Further, the list variables specifying the required RPMs were distinct and non-overlapping based on the major Linux release.

This change optimizes this area by:

1. Reorganizing the required package lists:
   - The `oracle_required_rpms` package list is now applicable to all distributions and major versions
   - Added or updated the version specific lists `oracle_required_rpms_el7`, `oracle_required_rpms_el8`, and `oracle_required_rpms_el9` containing linux version specific, additional packages
      - NOTE: The list of packages required based on Oracle Database Release 23 [Operating System Requirements for x86-64 Linux Platforms](https://docs.oracle.com/en/database/oracle/oracle-database/23/ladbi/operating-system-requirements-for-x86-64-linux-platforms.html) and Oracle Database 11g Release 2 [Oracle Database Preinstallation Tasks](https://docs.oracle.com/cd/E11882_01/install.112/e47689/pre_install.htm#BABCFJFG) documents and inspection of all available pre-installation RPM files (see details below)
1. Using a single `stat` and  single `set_fact` task to verify the presence of the (list defined) repository files and consequently reducing the list of associated installation operations to just four distinct tasks for:
   - RHEL7 with the `rh-cloud.repo` repo
   - RHEL7 without the `rh-cloud.repo` repo
   - Higher versions of RHEL (8+)
   - All versions of Oracle Linux

Additionally, this change includes some general package installation optimizations such as:

- Parameterize lock_timeout: `{{ dnf_lock_timeout }}` and deploy consistently to all package installation tasks
- Standardize on the `package` module over `yum` and `dnf` for consistency and version flexibility
- Format Ansible lists of dictionaries using proper YAML formatting structure

### Pre-installation Packages Inspected

Pre-installation RPM files inspected for package dependencies:

Oracle Linux 7:
```
oracle-database-preinstall-18c-1.0-1.el7.x86_64.rpm
oracle-database-preinstall-19c-1.0-3.el7.x86_64.rpm
oracle-database-preinstall-21c-1.0-1.el7.x86_64.rpm
oracle-database-server-12cR2-preinstall-1.0-5.el7.x86_64.rpm
oracle-rdbms-server-11gR2-preinstall-1.0-6.el7.x86_64.rpm
oracle-rdbms-server-12cR1-preinstall-1.0-7.el7.x86_64.rpm
```

Oracle Linux 8:
```
oracle-database-preinstall-19c-1.0-2.el8.x86_64.rpm
oracle-database-preinstall-21c-1.0-1.el8.x86_64.rpm
oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm
```

Oracle Linux 9:
```
oracle-database-preinstall-19c-1.0-1.el9.x86_64.rpm
oracle-database-preinstall-23ai-1.0-2.el9.x86_64.rpm
```

### Output Logs from Test Runs

Testing Oracle 11gR2 installs (with the `--no-patch` option) on **EL7** database servers:
- [RHEL7_Marketplace-11g-full-test-output-20250205_133442.txt](https://gist.github.com/simonpane/63653cd435a0a855b67c0530b8be8c0f)
- [RHEL7-11g-full-test-output-20250205_133656.txt](https://gist.github.com/simonpane/ee7450c127fcc5f3584a722e463e5ebe)
- [OL7-11g-full-test-output-20250205_133546.txt](https://gist.github.com/simonpane/a49f2ff163f59699b8951c37e2615555)

Testing Oracle 19c installs on **EL7** database servers:
- [RHEL7_Marketplace-19c-full-test-output-20250205_144507.txt](https://gist.github.com/simonpane/02ce559a301f05c8f50cf3af070248c5)
- [RHEL7-19c-full-test-output-20250205_150209.txt](https://gist.github.com/simonpane/191712bc5f8f06aa3977769affdf4342)
- [OL7-19c-full-test-output-20250205_150225.txt](https://gist.github.com/simonpane/4f7c9cf914f5be09c64aef394b100210)

Testing Oracle 19c installs on **EL8** database servers:
- [RHEL8_Marketplace-19c-full-test-output-20250205_160739.txt](https://gist.github.com/simonpane/b0ee377585ed6d6230b1924b90931415)
- [RHEL8-19c-full-test-output-20250205_160603.txt](https://gist.github.com/simonpane/fc4032e4cb6194c3044fc995980fef9f)
- [OL8-19c-full-test-output-20250205_161152.txt](https://gist.github.com/simonpane/f50e03fbbd75689c4eb59e9d001def97)