### PR TITLE
Ansible linting and formatting adjustments (no logic changes)

### DIFF
--- a/check-instance.yml
+++ b/check-instance.yml
@@ -22,14 +22,14 @@
         fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
         success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
     - block:
-      - name: Confirm JSON parsing works
-        assert:
-          that: "{{ '{}' | json_query('[0]') == None }}"
+        - name: Confirm JSON parsing works
+          assert:
+            that: "{{ '{}' | json_query('[0]') == None }}"
       rescue:
         - name: Check for JSON parse failure
           fail:
             msg: "You probably need to install Python jmespath on the control node"
-  
+
   tasks:
     - name: Test connectivity to target instance via ping
       ping:

--- a/roles/base-provision/handlers/main.yml
+++ b/roles/base-provision/handlers/main.yml
@@ -15,7 +15,11 @@
 ---
 # handlers file for init
 - name: restart dnsmasq
-  service: name=dnsmasq state=restarted
+  service:
+    name: dnsmasq
+    state: restarted
 
 - name: restart chronyd
-  service: name=chronyd state=restarted
+  service:
+    name: chronyd
+    state: restarted

--- a/roles/check-swlib/tasks/main.yml
+++ b/roles/check-swlib/tasks/main.yml
@@ -89,7 +89,7 @@
     msg: |
       MD5 mismatch: expected {{ item.item.md5sum }} got {{ item.stdout_lines }}
       for {{ item.item.name }} {{ item.item.files }}
-  when: item.failed is defined and item.failed == true
+  when: item.failed is defined and item.failed
   with_items:
     - "{{ base_repo_files.results }}"
 
@@ -98,7 +98,7 @@
     msg: |
       MD5 mismatch: expected {{ item.item.md5sum }} got {{ item.stdout_lines }}
       for {{ item.item.category }} patch {{ item.item.patchfile }}
-  when: item.failed is defined and item.failed == true
+  when: item.failed is defined and item.failed
   with_items:
     - "{{ patch_repo_files.results }}"
     - "{{ opatch_repo_files.results }}"

--- a/roles/db-create/tasks/rac-db-create.yml
+++ b/roles/db-create/tasks/rac-db-create.yml
@@ -238,7 +238,8 @@
       become_user: "{{ oracle_user }}"
 
     - name: rac-db-create | Show datapatch results
-      debug: var=datapatch_output.stdout_lines
+      debug:
+        var: datapatch_output.stdout_lines
       when: oracle_ver != '11.2.0.4.0'
 
     - name: rac-db-create | Set cluster_database to true

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -105,7 +105,8 @@
   tags: dg-create
 
 - name: DG | DG creation output
-  debug: var=dg_create.stdout_lines
+  debug:
+    var: dg_create.stdout_lines
   tags: dg-create
 
 - name: DG | Wait for DG to be enabled
@@ -128,7 +129,8 @@
   tags: dg-create
 
 - name: DG | DG verbose output
-  debug: var=dg_create.stdout_lines
+  debug:
+    var: dg_create.stdout_lines
   tags: dg-create
 
 - name: DG | Show standby database configuration

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -121,7 +121,6 @@
   become: true
   become_user: "{{ grid_user }}"
   command: "sh {{ swlib_unzip_path }}/grid_install.rsp.sh"
-  args:
   tags: gi-setup
 
 - name: gi-install | Script cleanup

--- a/roles/hugepages/tasks/main.yml
+++ b/roles/hugepages/tasks/main.yml
@@ -65,7 +65,11 @@
 - debug: var=ram_pct_used
 
 - name: configure memlock limits
-  pam_limits: domain=oracle limit_type={{ item }} limit_item=memlock value=unlimited
+  pam_limits:
+    domain: oracle
+    limit_type: "{{ item }}"
+    limit_item: memlock
+    value: unlimited
   with_items:
     - soft
     - hard
@@ -113,14 +117,16 @@
   ignore_errors: true
   changed_when: false
 
-- debug: var=checkTPH
+- debug:
+    var: checkTPH
 
 - name: Update Grub default config
   shell: grubby --args="transparent_hugepage=never" --update-kernel=ALL
   when: checkTPH.stdout == "[always] madvise never" or checkTPH.stdout == "always [madvise] never"
   register: grubbyTPH
 
-- debug: var=grubbyTPH
+- debug:
+    var: grubbyTPH
 
 - name: Temporary run-time disabling of THP
   shell: |

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -23,12 +23,16 @@
   register: firewall
 
 - name: Disable firewall
-  service: name={{ firewall_service }} state=stopped enabled=no
+  service:
+    name: "{{ firewall_service }}"
+    state: stopped
+    enabled: false
   when: disable_firewall|bool and ansible_os_family == 'RedHat' and firewall.results
   tags: firewall
 
 - name: Disable selinux (permanently)
-  selinux: state=disabled
+  selinux:
+    state: disabled
   when: disable_selinux and ansible_os_family == 'RedHat'
   tags: selinux
   register: selinux

--- a/roles/patch/tasks/opatch_apply.yml
+++ b/roles/patch/tasks/opatch_apply.yml
@@ -102,5 +102,5 @@
   include_tasks: sql_patch.yml
   when:
     - home_type == 'DB' or patch.method == 'opatch apply'
-    - standby_db|default(false)|bool == false
+    - not (standby_db | default(false) | bool)
   tags: patch-rdbms,opatch-apply

--- a/roles/patch/tasks/rac-dbpatch.yml
+++ b/roles/patch/tasks/rac-dbpatch.yml
@@ -94,7 +94,8 @@
   tags: patch_rdbms,datapatch
 
 - name: rac-dbpatch | Datapatch results
-  debug: var=datapatch_output.stdout_lines
+  debug:
+    var: datapatch_output.stdout_lines
   when: oracle_ver != '11.2.0.4.0'
   tags: patch_rdbms,datapatch
 
@@ -116,7 +117,8 @@
   tags: patch_rdbms,catbundle
 
 - name: rac-dbpatch | Catbundle results
-  debug: var=catbundle_output
+  debug:
+    var: catbundle_output
   when: oracle_ver == '11.2.0.4.0'
   tags: patch_rdbms,catbundle
 
@@ -154,7 +156,8 @@
   tags: patch_rdbms
 
 - name: rac-dbpatch | Registry patch results
-  debug: var=patch_registry.stdout_lines
+  debug:
+    var: patch_registry.stdout_lines
   when: oracle_ver != '11.2.0.4.0'
 
 - name: rac-dbpatch | Set cluster_database to true
@@ -221,7 +224,8 @@
   tags: patch_rdbms,datapatch
 
 - name: rac-dbpatch | Datapatch results for second time
-  debug: var=datapatch_output2.stdout_lines
+  debug:
+    var: datapatch_output2.stdout_lines
   when: oracle_ver != '11.2.0.4.0'
   tags: patch_rdbms,datapatch
 

--- a/roles/patch/tasks/rac-opatch.yml
+++ b/roles/patch/tasks/rac-opatch.yml
@@ -54,7 +54,8 @@
   tags: rac-opatch
 
 - name: rac-opatch | GI opatch analyze output
-  debug: var=opatch_analyze.results.0.stdout_lines
+  debug:
+    var: opatch_analyze.results.0.stdout_lines
   when: opatch_analyze is defined
   tags: rac-opatch
 
@@ -156,7 +157,8 @@
   tags: rac-opatch
 
 - name: rac-opatch | Results of GI opatch apply
-  debug: var=opatch_apply.results.0.stdout_lines
+  debug:
+    var: opatch_apply.results.0.stdout_lines
   when: opatch_apply is defined
   tags: rac-opatch
 
@@ -177,7 +179,8 @@
   tags: rac-opatch
 
 - name: rac-opatch | 12.1 bug resolution results
-  debug: var=setasmgidwrap_output
+  debug:
+    var: setasmgidwrap_output
   when: oracle_ver == '12.1.0.2.0'
   tags: rac-opatch
 
@@ -219,7 +222,8 @@
   tags: rac-opatch
 
 - name: rac-opatch | RDBMS opatch analyze output
-  debug: var=rdbms_analyze.results.0.stdout_lines
+  debug:
+    var: rdbms_analyze.results.0.stdout_lines
   when: rdbms_analyze is defined
   tags: rac-opatch
 
@@ -237,7 +241,8 @@
   tags: rac-opatch
 
 - name: rac-opatch | Results of RDBMS opatch apply
-  debug: var=rdbms_apply.results.0.stdout_lines
+  debug:
+    var: rdbms_apply.results.0.stdout_lines
   when: rdbms_apply is defined
   tags: rac-opatch
 


### PR DESCRIPTION
Ansible linting and formatting adjustments (no logic changes)

Lower-risk Ansible linting and formatting adjustments.  Mostly based on indentation and white space fixes plus the Ansible lint checks:

- [no-free-form](https://ansible.readthedocs.io/projects/lint/rules/no-free-form/)
- [schema](https://ansible.readthedocs.io/projects/lint/rules/schema/)
- [literal-compare](https://ansible.readthedocs.io/projects/lint/rules/literal-compare/)

> **NOTE:** some occurrences of the "**no-free-form**" violation not corrected in role `hugepages` as those tasks relate to redundant kernel parameter setting tasks - these tasks are being addressed separately in a forthcoming PR.
