### PR TITLE
Add support for installing the latest Oracle Database 23ai Free Edition: version `23.7.0.25.01`

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2351,20 +2351,12 @@ Specific supported versions of Oracle Database 23 free edition currently include
 |   23c   |   23.3.0.23.09   | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 |   23c   |    23.2.0.0.0    | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 
-Even though the file names may be the same while the version changes, multiple files with the same name can be kept in the software library. Possibly by manually changing the file names (and then updating the `rdbms_software` variables in the YAML files accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders** for uniquness.
+Even though the file names may be the same while the version changes, the RPMs for the various versions can still be staged in the software library. Possibly by manually changing the file names for uniqueness (and then updating the `rdbms_software` variable in the [roles/common/defaults/main.yml](../roles/common/defaults/main.yml) YAML file accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders**.
 
-If the specific version desired is not specified via a command line switch (or corresponding environment variable), the toolkit will default to the most recent version – currently version `23.7.0.25.01`.
+If no Free Edition version is explicitly defined (via the `--ora-version` command line switch or the corresponding environment variable), the toolkit will default to the most recent version.
 
-Otherwise, one of the following command line switches should be used to install a specific free edition version:
+If a specific version is required, it can be specified using the `--ora-version` command line switch and one of the above listed version values. For example: `--ora-version 23.6.0.24.10` or `--ora-version 23.2.0.0.0`.
 
-```bash
- --ora-version 23.7.0.25.01
- --ora-version 23.6.0.24.10
- --ora-version 23.5.0.24.07
- --ora-version 23.4.0.24.05
- --ora-version 23.3.0.23.09
- --ora-version 23.2.0.0.0
-```
 
 #### Free edition specific parameter changes
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2351,12 +2351,11 @@ Specific supported versions of Oracle Database 23 free edition currently include
 |   23c   |   23.3.0.23.09   | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 |   23c   |    23.2.0.0.0    | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 
-Even though the file names may be the same while the version changes, the RPMs for the various versions can still be staged in the software library. Possibly by manually changing the file names for uniqueness (and then updating the `rdbms_software` variable in the [roles/common/defaults/main.yml](../roles/common/defaults/main.yml) YAML file accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders**.
+Even though the file names may be the same while the version changes, the RPMs for the various versions can still be staged in the software library. Possibly by manually changing the file names for uniqueness (and then updating the `rdbms_software` variable in the [roles/common/defaults/main.yml](../roles/common/defaults/main.yml) file accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders**.
 
 If no Free Edition version is explicitly defined (via the `--ora-version` command line switch or the corresponding environment variable), the toolkit will default to the most recent version.
 
 If a specific version is required, it can be specified using the `--ora-version` command line switch and one of the above listed version values. For example: `--ora-version 23.6.0.24.10` or `--ora-version 23.2.0.0.0`.
-
 
 #### Free edition specific parameter changes
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2342,21 +2342,23 @@ Oracle has released serveral versions of free edition, often **without chaning t
 
 Specific supported versions of Oracle Database 23 free edition currently includes:
 
-| Product | Specific Version | Software RPM Filename                                  | Preinstall RPM Filename                                |
-| :-----: | :--------------: | :----------------------------------------------------- | :----------------------------------------------------- |
-|  23ai   |   23.6.0.24.10   | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|  23ai   |   23.5.0.24.07   | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|  23ai   |   23.4.0.24.05   | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|   23c   |   23.3.0.23.09   | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
-|   23c   |    23.2.0.0.0    | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
+| Product | Specific Version | Software RPM Filename                            | Preinstall RPM Filename                                |
+| :-----: | :--------------: | :----------------------------------------------- | :----------------------------------------------------- |
+|  23ai   |   23.7.0.25.01   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.6.0.24.10   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.5.0.24.07   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.4.0.24.05   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|   23c   |   23.3.0.23.09   | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
+|   23c   |    23.2.0.0.0    | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 
 Even though the file names may be the same while the version changes, multiple files with the same name can be kept in the software library. Possibly by manually changing the file names (and then updating the `rdbms_software` variables in the YAML files accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders** for uniquness.
 
-If the specific version desired is not specified via a command line switch (or corresponding environment variable), the toolkit will default to the most recent version – currently version `23.6.0.24.10`.
+If the specific version desired is not specified via a command line switch (or corresponding environment variable), the toolkit will default to the most recent version – currently version `23.7.0.25.01`.
 
 Otherwise, one of the following command line switches should be used to install a specific free edition version:
 
 ```bash
+ --ora-version 23.7.0.25.01
  --ora-version 23.6.0.24.10
  --ora-version 23.5.0.24.07
  --ora-version 23.4.0.24.05
@@ -2394,6 +2396,7 @@ ORA_VERSION
 --ora-version
 </pre></p></td>
 <td>
+23.7.0.25.01<br>
 23.6.0.24.10<br>
 23.5.0.24.07<br>
 23.4.0.24.05<br>

--- a/roles/brute-ora-cleanup/README.md
+++ b/roles/brute-ora-cleanup/README.md
@@ -25,7 +25,7 @@ Sample brute force clean-up for Free Edition using the included shell script:
 ```bash
 ./cleanup-oracle.sh \
   --ora-edition FREE \
-  --ora-version 23.6.0.24.10 \
+  --ora-version 23.7.0.25.01 \
   --inventory-file inventory_files/inventory_10.2.80.54_FREE \
   --yes-i-am-sure
 ```

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -171,12 +171,25 @@ gi_software:
       - "BM7zeZHbGPgZD31KGbJpEg=="
 
 rdbms_software:
+  - name: 23aiFREE_23_7
+    version: 23.7.0.25.01
+    edition: FREE
+    files:
+      - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
+    sha256sum:
+      - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
+      - "af64450e1120e56dac43a447a2e109449c7590489003d830d6a32a9168e0469d"
+    md5sum:
+      - "TmjqUT878Owv7NbXGECpTA=="
+      - "a838g/xuUjrVkzM2S5AUug=="
+
   - name: 23aiFREE_23_6
     version: 23.6.0.24.10
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_6.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "03ae958784e9443c0380e4d387cb0522016c72d029ab85cf55ee124489833e0e"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -171,7 +171,7 @@ gi_software:
       - "BM7zeZHbGPgZD31KGbJpEg=="
 
 rdbms_software:
-  - name: 23aiFREE_23_7
+  - name: 23ai_free_23_7
     version: 23.7.0.25.01
     edition: FREE
     files:
@@ -184,12 +184,12 @@ rdbms_software:
       - "TmjqUT878Owv7NbXGECpTA=="
       - "a838g/xuUjrVkzM2S5AUug=="
 
-  - name: 23aiFREE_23_6
+  - name: 23ai_free_23_6
     version: 23.6.0.24.10
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_6.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "03ae958784e9443c0380e4d387cb0522016c72d029ab85cf55ee124489833e0e"
@@ -197,12 +197,12 @@ rdbms_software:
       - "TmjqUT878Owv7NbXGECpTA=="
       - "Y70TVN1a7dV6TnNOeN1pYA=="
 
-  - name: 23aiFREE_23_5
+  - name: 23ai_free_23_5
     version: 23.5.0.24.07
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_5.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "80c1ceae3b158cffe71fa4cfa8e4f540161659f79f777bcf48935f79031c054c"
@@ -210,12 +210,12 @@ rdbms_software:
       - "TmjqUT878Owv7NbXGECpTA=="
       - "cWcZFOhqt4Bnwt4rft6wpw=="
 
-  - name: 23aiFREE_23_4
+  - name: 23ai_free_23_4
     version: 23.4.0.24.05
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_4.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "e6cccec7f101325c233f374c2aa86f77d62123edd3125450d79404c3eec30b65"
@@ -223,12 +223,12 @@ rdbms_software:
       - "TmjqUT878Owv7NbXGECpTA=="
       - "nZiDvGPHVa8iDkR110gB8A=="
 
-  - name: 23cFREE_23_3
+  - name: 23c_free_23_3
     version: 23.3.0.23.09
     edition: FREE
     files:
       - "oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm"
-      - "oracle-database-free-23c-1.0-1.el8.x86_64.version_23_3.rpm"
+      - "oracle-database-free-23c-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "f41059c22a610a2180cc6286179a7da148bfe14b0d88211f006c9998ce03ba0e"
       - "1319bcd7cb706cb727501cbd98abf3f3980a4fdabeb613a1abffc756925c7374"
@@ -236,12 +236,12 @@ rdbms_software:
       - "lVoplyvF66eUXign+DuZ8Q=="
       - "k+q8twMOziARmih9mF79ow=="
 
-  - name: 23cFREE_23_2
+  - name: 23c_free_23_2
     version: 23.2.0.0.0
     edition: FREE
     files:
       - "oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm"
-      - "oracle-database-free-23c-1.0-1.el8.x86_64.version_23_2.rpm"
+      - "oracle-database-free-23c-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "f41059c22a610a2180cc6286179a7da148bfe14b0d88211f006c9998ce03ba0e"
       - "63b6c0ec9464682cfd9814e7e2a5d533139e5c6aeb9d3e7997a5f976d6677ca6"

--- a/roles/db-create/defaults/main.yml
+++ b/roles/db-create/defaults/main.yml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 ---
-dbca_extra_args: "{% if free_edition %}-skipDatapatch TRUE -useOMF {{ use_omf }} -recoveryAreaSize 1638{% endif %}"
+dbca_extra_args: "{% if free_edition %}-skipDatapatch TRUE -useOMF {{ use_omf }}{% endif %}"

--- a/roles/rdbms-setup/defaults/main.yml
+++ b/roles/rdbms-setup/defaults/main.yml
@@ -14,7 +14,7 @@
 
 ---
 rdbms_software:
-  - name: 23aiFREE_23_7
+  - name: 23ai_free_23_7
     version: 23.7.0.25.01
     edition: FREE
     files:
@@ -23,48 +23,48 @@ rdbms_software:
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "af64450e1120e56dac43a447a2e109449c7590489003d830d6a32a9168e0469d"
-  - name: 23aiFREE_23_6
+  - name: 23ai_free_23_6
     version: 23.6.0.24.10
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_6.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "03ae958784e9443c0380e4d387cb0522016c72d029ab85cf55ee124489833e0e"
-  - name: 23aiFREE_23_5
+  - name: 23ai_free_23_5
     version: 23.5.0.24.07
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_5.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "80c1ceae3b158cffe71fa4cfa8e4f540161659f79f777bcf48935f79031c054c"
-  - name: 23aiFREE_23_4
+  - name: 23ai_free_23_4
     version: 23.4.0.24.05
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_4.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "e6cccec7f101325c233f374c2aa86f77d62123edd3125450d79404c3eec30b65"
-  - name: 23cFREE_23_3
+  - name: 23c_free_23_3
     version: 23.3.0.23.09
     edition: FREE
     files:
       - "oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm"
-      - "oracle-database-free-23c-1.0-1.el8.x86_64.version_23_3.rpm"
+      - "oracle-database-free-23c-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "f41059c22a610a2180cc6286179a7da148bfe14b0d88211f006c9998ce03ba0e"
       - "1319bcd7cb706cb727501cbd98abf3f3980a4fdabeb613a1abffc756925c7374"
-  - name: 23cFREE_23_2
+  - name: 23c_free_23_2
     version: 23.2.0.0.0
     edition: FREE
     files:
       - "oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm"
-      - "oracle-database-free-23c-1.0-1.el8.x86_64.version_23_2.rpm"
+      - "oracle-database-free-23c-1.0-1.el8.x86_64.rpm"
     sha256sum:
       - "f41059c22a610a2180cc6286179a7da148bfe14b0d88211f006c9998ce03ba0e"
       - "63b6c0ec9464682cfd9814e7e2a5d533139e5c6aeb9d3e7997a5f976d6677ca6"

--- a/roles/rdbms-setup/defaults/main.yml
+++ b/roles/rdbms-setup/defaults/main.yml
@@ -14,12 +14,21 @@
 
 ---
 rdbms_software:
+  - name: 23aiFREE_23_7
+    version: 23.7.0.25.01
+    edition: FREE
+    files:
+      - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
+    sha256sum:
+      - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
+      - "af64450e1120e56dac43a447a2e109449c7590489003d830d6a32a9168e0469d"
   - name: 23aiFREE_23_6
     version: 23.6.0.24.10
     edition: FREE
     files:
       - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
-      - "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm"
+      - "oracle-database-free-23ai-1.0-1.el8.x86_64.version_23_6.rpm"
     sha256sum:
       - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
       - "03ae958784e9443c0380e4d387cb0522016c72d029ab85cf55ee124489833e0e"


### PR DESCRIPTION
## Change Description:

Add support for installing the latest Oracle Database 23ai Free Edition: version `23.7.0.25.01`.

## Solution Overview:

Updated toolkit Ansible and documentation files to support the latest `23.7.0.25.01` release of 23ai Free Edition. This is now the Free Edition version that will be installed by default as the the most recent version.

Also, remove the Free Edition unique manual specification of the DBCA option `-recoveryAreaSize` using a fixed size value.

## Test Commands:

### Test 1: Run a complete 23ai Free Edition install:

Install the "latest" version of 23ai Free Edition by default (i.e. by not explicitly stating a specific version):

```bash
./check-swlib.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition --ora-edition free

export INSTANCE_IP_ADDR=10.2.80.109

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition free \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

ssh -t ${INSTANCE_IP_ADDR} <<EOF 2>/dev/null
sudo -i -u oracle sqlplus -s / as sysdba <<'SQL'
select version_full from v\$instance;
exit
SQL
EOF

./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.7.0.25.01 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --yes-i-am-sure
```

### Test 2: Run a custom version of 23ai Free Edition full installation:

Install a specific (older) version of 23ai Free Edition by including the `--ora-version` argument and an older version as the value:

```bash
export INSTANCE_IP_ADDR=10.2.80.109

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-version 23.6.0.24.10 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

ssh -t ${INSTANCE_IP_ADDR} <<EOF 2>/dev/null
sudo -i -u oracle sqlplus -s / as sysdba <<'SQL'
select version_full from v\$instance;
exit
SQL
EOF

./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.6.0.24.10 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --yes-i-am-sure
```

### Test 3: Run a custom version of 23ai Free Edition full installation using a short version value:

Default to the most recent version of 23ai Free Edition if the `--ora-version 23` argument is included:

```bash
export INSTANCE_IP_ADDR=10.2.80.109

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-version 23 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

ssh -t ${INSTANCE_IP_ADDR} <<EOF 2>/dev/null
sudo -i -u oracle sqlplus -s / as sysdba <<'SQL'
select version_full from v\$instance;
exit
SQL
EOF

./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.7.0.25.01 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --yes-i-am-sure
```

## Results:

- [oratk-91: Test 1 Full test run output](https://gist.github.com/simonpane/db43068a7e72710c793e3eb51f1995b7)
- [oratk-91: Test 2 Full test run output](https://gist.github.com/simonpane/9551100a6bcdddbd6540d0c1a021d3e0)
- [oratk-91: Test 3 Full test run output](https://gist.github.com/simonpane/6efefb248ce0ebb5845543dfafe4d6ba)
