### PR TITLE
Add options to pass configurations from JSON files directly in CLI

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,8 +28,8 @@ published: True
       - [NFS share](#nfs-share)
     - [Validating Media](#validating-media)
   - [Prerequisite configuration](#prerequisite-configuration)
-    - [Data mount configuration file](#data-mount-configuration-file)
-    - [ASM disk group configuration file](#asm-disk-group-configuration-file)
+    - [Data mounts configuration](#data-mounts-configuration)
+    - [ASM disk groups configuration](#asm-disk-groups-configuration)
     - [Specifying LVM logical volumes](#specifying-lvm-logical-volumes)
   - [Configuring Installations](#configuring-installations)
     - [Configuration defaults](#configuration-defaults)
@@ -124,9 +124,12 @@ Initial steps similar to those of the Single Instance installation.
 
    `./install-oracle.sh --help`
 
-1. Create the cluster configuration file by editing the `cluster_config.json` file template that is provided with the toolkit.
+1. Create the cluster configuration. You have two options:
+   1. edit the `cluster_config.json` JSON file template that is provided with the toolkit, 
+and supply its location as `--cluster-config` parameter
+   1. supply the cluster configuration JSON directly as `--cluster-config-json` parameter   
 
-1. Install the database with the path to the cluster configuration file specified on the `--cluster-config` property:
+1. Install the database:
 
    ```bash
    ./install-oracle.sh \
@@ -135,7 +138,7 @@ Initial steps similar to those of the Single Instance installation.
    --ora-swlib-path /u02/swlib/ \
    --ora-swlib-type gcs \
    --cluster-type RAC \
-   --cluster-config cluster_config.json
+   --cluster-config-json '[ { "scan_name": ... } ]'
    ```
 
 ## Command quick reference for DR deployments
@@ -1154,31 +1157,32 @@ Found p6880880_122010_Linux-x86-64.zip : OPatch Utility
 
 ## Prerequisite configuration
 
-Before you run the tool you need to create JSON formatted configuration files
-for the data mount devices and the ASM disk group.
+Before you run the tool you need to create JSON formatted configurations
+for the data mount devices and the ASM disk group. They can be stored in files or passed via CLI parameters.
 
 The [host provisinoing tool](host-provisioning.md) can configure newly-provisioned
 BMS hosts to run the toolkit installer, including authentication, Internet access,
 and local mountpoints.
 
-### Data mount configuration file
+### Data mounts configuration
 
-In the data mount configuration file, you specify disk device attributes for:
+In the data mounts configuration, you specify disk device attributes for:
 
-- Oracle software installation, which is usually mounted at /u01
-- Oracle diagnostic destination, which is usually mounted at /u02
+- Oracle software installation, which is usually mounted at `/u01`
+- Oracle diagnostic destination, which is usually mounted at `/u02`
 
-In the configuration file, specify the block devices (actual devices, not
+Specify the block devices (actual devices, not
 partitions), the mount point names, the file system types, and the mount options
-in valid JSON format.
+in a valid JSON format.
 
 When you run the toolkit, specify the path to the configuration file by using
 either the `--ora-data-mounts` command line option or the
 `ORA_DATA_MOUNTS` environment variable. The file path can be relative or
 fully qualified. The file name defaults to `data_mounts_config.json`.
+Alternatively, pass the file content directly as a JSON using `--ora-data-mounts-json` parameter. 
+CLI argument overrides file content, if both are present.
 
-The following example shows a properly formatted JSON data mount configuration
-file:
+The following example shows a properly formatted JSON data mounts configuration file:
 
 ```json
 [
@@ -1201,19 +1205,19 @@ file:
 ]
 ```
 
-### ASM disk group configuration file
+### ASM disk groups configuration
 
-In the ASM disk group configuration, specify the disk group names, the ASM disk
-names, and the associated block devices (the actual devices, not partitions) in
+In the ASM disk groups configuration, specify the disk group names, the disk
+names, and the associated block devices (the actual devices, not partitions) in a
 valid JSON format.
 
 When you run the toolkit, specify the path to the configuration file by using
 either the `--ora-asm-disks` command line option or the `ORA_ASM_DISKS`
 environment variable. The file path can be relative or fully qualified. The file
-name defaults to `ask_disk_config.json`.
+name defaults to `ask_disk_config.json`. Alternatively, pass the file content directly
+as a JSON using `--ora-asm-disks-json` parameter. CLI argument overrides file content, if both are present.
 
-The following example shows a properly formatted JSON ASM disk group
-configuration file:
+The following example shows a properly formatted JSON ASM disk groups configuration file:
 
 ```json
 [
@@ -1261,7 +1265,7 @@ argument displays the list of available options.
 Although the toolkit provides defaults for just about everything, in most cases,
 you need to customize your installation to some degree. Your customizations can
 range from simple items, such as the name of a database or the associated
-database edition, to less frequently adjusted items, such as ASM disk group
+database edition, to less frequently adjusted items, such as ASM disk groups
 configurations. Regardless, the toolkit allows you to specify overrides for most
 configuration parameters.
 
@@ -1529,7 +1533,21 @@ data_mounts_config.json</td>
 <td>Properly formatted JSON file providing mount and file system details for
 local mounts including installation location for the Oracle software and
 the location for Oracle diagnostic (ADR) directories. See <a
-href="#data-mount-configuration-file">Data mount configuration file</a>.</td>
+href="#data-mounts-configuration">Data mounts configuration</a>.</td>
+</tr>
+<tr>
+<td>Storage configuration</td>
+<td><br>
+<p><pre>
+ORA_DATA_MOUNTS_JSON
+--ora-data-mounts-json
+</pre></p></td>
+<td>user defined<br>
+</td>
+<td>Properly formatted JSON providing mount and file system details for
+local mounts including installation location for the Oracle software and
+the location for Oracle diagnostic (ADR) directories. See <a
+href="#data-mounts-configuration">Data mounts configuration</a>.</td>
 </tr>
 <tr>
 <td>Software unzip location</td>
@@ -1645,16 +1663,25 @@ RECO</td>
 <td>Default disk group for FRA files for initial database.</td>
 </tr>
 <tr>
-<td>ASM disk configuration</td>
+<td>ASM disk groups configuration</td>
 <td><p><pre>
 ORA_ASM_DISKS
 --ora-asm-disks
 </pre></p></td>
 <td>user defined<br>
 asm_disk_config.json</td>
-<td>Name of an ASM configuration file that contains ASM disk definitions in
-valid JSON format. See <a href="#asm-disk-group-configuration-file">ASM disk group
-configuration file</a>.</td>
+<td>Name of an ASM configuration file that contains ASM disk groups definitions in
+valid JSON format. See <a href="#asm-disk-groups-configuration">ASM disk groups configuration</a>.</td>
+</tr>
+<tr>
+<td>ASM disk groups configuration</td>
+<td><p><pre>
+ORA_ASM_DISKS_JSON
+--ora-asm-disks-json
+</pre></p></td>
+<td>user defined<br></td>
+<td>ASM disk groups definition in a valid JSON format. 
+See <a href="#asm-disk-groups-configuration">ASM disk groups configuration</a>.</td>
 </tr>
 </tbody>
 </table>
@@ -1802,21 +1829,29 @@ NONE<br>
 RAC<br>
 DG
 </td>
-<td>Specify "RAC" to install a RAC cluster. Use "DG" for standby installation. Otherwise a "Single Instance"
-installation is performed.</td>
+<td>Specify "RAC" to provision Real Application Clusters. Use "DG" for standby installation.
+Otherwise, a "Single Instance" installation is performed.</td>
 </tr>
 <tr>
-<td>RAC specific configuration parameters</td>
+<td>Cluster configuration file</td>
 <td><p><pre>
 CLUSTER_CONFIG
 --cluster-config
 </pre></p></td>
-<td>user defined<br>
-cluster_config.json</td>
-<td>Used to specify the RAC scan listener name, port, IPs, and so forth. Also
-used to list RAC nodes.<br>
-<br>
-Specifies a file containing properly formed JSON text.</td>
+<td>user defined; defaults to<br>
+<pre>cluster_config.json</pre></td>
+<td>A file name for the cluster configuration JSON.<br>
+Use the file to specify the RAC SCAN listener name, port, IPs, nodes, etc.</td>
+</tr>
+<tr>
+<td>Cluster configuration JSON</td>
+<td><p><pre>CLUSTER_CONFIG_JSON
+--cluster-config-json
+</pre></p></td>
+<td>user defined</td>
+<td>Cluster configuration JSON. Use it to specify the RAC SCAN listener name, port, IPs, nodes, etc. 
+on the CLI instead of the CLUSTER_CONFIG file.
+</td>
 </tr>
 </tbody>
 </table>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,7 +28,7 @@ published: True
       - [NFS share](#nfs-share)
     - [Validating Media](#validating-media)
   - [Prerequisite configuration](#prerequisite-configuration)
-    - [Data mounts configuration](#data-mounts-configuration)
+    - [Data mount configuration](#data-mount-configuration)
     - [ASM disk groups configuration](#asm-disk-groups-configuration)
     - [Specifying LVM logical volumes](#specifying-lvm-logical-volumes)
   - [Configuring Installations](#configuring-installations)
@@ -125,9 +125,9 @@ Initial steps similar to those of the Single Instance installation.
    `./install-oracle.sh --help`
 
 1. Create the cluster configuration. You have two options:
-   1. edit the `cluster_config.json` JSON file template that is provided with the toolkit, 
-and supply its location as `--cluster-config` parameter
-   1. supply the cluster configuration JSON directly as `--cluster-config-json` parameter   
+   1. Edit the `cluster_config.json` JSON file template that is provided with the toolkit, 
+and then specify its path using the `--cluster-config` parameter
+   1. Pass the cluster configuration JSON as an argument to the `--cluster-config-json` parameter   
 
 1. Install the database:
 
@@ -1157,32 +1157,32 @@ Found p6880880_122010_Linux-x86-64.zip : OPatch Utility
 
 ## Prerequisite configuration
 
-Before you run the tool you need to create JSON formatted configurations
-for the data mount devices and the ASM disk group. They can be stored in files or passed via CLI parameters.
+Create JSON formatted configurations for the data mount devices and the ASM disk group.
+They can be stored in files or passed via CLI parameters.
 
 The [host provisinoing tool](host-provisioning.md) can configure newly-provisioned
 BMS hosts to run the toolkit installer, including authentication, Internet access,
 and local mountpoints.
 
-### Data mounts configuration
+### Data mount configuration
 
-In the data mounts configuration, you specify disk device attributes for:
+In the data mount configuration, you specify disk device attributes for:
 
 - Oracle software installation, which is usually mounted at `/u01`
 - Oracle diagnostic destination, which is usually mounted at `/u02`
 
 Specify the block devices (actual devices, not
 partitions), the mount point names, the file system types, and the mount options
-in a valid JSON format.
+in valid JSON format.
 
 When you run the toolkit, specify the path to the configuration file by using
 either the `--ora-data-mounts` command line option or the
 `ORA_DATA_MOUNTS` environment variable. The file path can be relative or
 fully qualified. The file name defaults to `data_mounts_config.json`.
-Alternatively, pass the file content directly as a JSON using `--ora-data-mounts-json` parameter. 
-CLI argument overrides file content, if both are present.
+Alternatively, pass the file content directly as JSON using `--ora-data-mounts-json` parameter. 
+If both are present, `--ora-data-mounts-json` takes precedence.
 
-The following example shows a properly formatted JSON data mounts configuration file:
+The following example shows a properly formatted JSON data mount configuration file:
 
 ```json
 [
@@ -1215,7 +1215,8 @@ When you run the toolkit, specify the path to the configuration file by using
 either the `--ora-asm-disks` command line option or the `ORA_ASM_DISKS`
 environment variable. The file path can be relative or fully qualified. The file
 name defaults to `ask_disk_config.json`. Alternatively, pass the file content directly
-as a JSON using `--ora-asm-disks-json` parameter. CLI argument overrides file content, if both are present.
+as a JSON using `--ora-asm-disks-json` parameter. If both are present, 
+`--ora-asm-disks-json` takes precedence.
 
 The following example shows a properly formatted JSON ASM disk groups configuration file:
 
@@ -1533,7 +1534,7 @@ data_mounts_config.json</td>
 <td>Properly formatted JSON file providing mount and file system details for
 local mounts including installation location for the Oracle software and
 the location for Oracle diagnostic (ADR) directories. See <a
-href="#data-mounts-configuration">Data mounts configuration</a>.</td>
+href="#data-mount-configuration">Data mount configuration</a>.</td>
 </tr>
 <tr>
 <td>Storage configuration</td>
@@ -1547,7 +1548,7 @@ ORA_DATA_MOUNTS_JSON
 <td>Properly formatted JSON providing mount and file system details for
 local mounts including installation location for the Oracle software and
 the location for Oracle diagnostic (ADR) directories. See <a
-href="#data-mounts-configuration">Data mounts configuration</a>.</td>
+href="#data-mount-configuration">Data mount configuration</a>.</td>
 </tr>
 <tr>
 <td>Software unzip location</td>
@@ -1829,8 +1830,8 @@ NONE<br>
 RAC<br>
 DG
 </td>
-<td>Specify "RAC" to provision Real Application Clusters. Use "DG" for standby installation.
-Otherwise, a "Single Instance" installation is performed.</td>
+<td>Specify RAC to provision Real Application Clusters. Use DG for standby installation.
+Otherwise, a Single Instance installation is performed.</td>
 </tr>
 <tr>
 <td>Cluster configuration file</td>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -29,7 +29,7 @@ published: True
     - [Validating Media](#validating-media)
   - [Prerequisite configuration](#prerequisite-configuration)
     - [Data mount configuration](#data-mount-configuration)
-    - [ASM disk groups configuration](#asm-disk-groups-configuration)
+    - [ASM disk group configuration](#asm-disk-group-configuration)
     - [Specifying LVM logical volumes](#specifying-lvm-logical-volumes)
   - [Configuring Installations](#configuring-installations)
     - [Configuration defaults](#configuration-defaults)
@@ -1205,9 +1205,9 @@ The following example shows a properly formatted JSON data mount configuration f
 ]
 ```
 
-### ASM disk groups configuration
+### ASM disk group configuration
 
-In the ASM disk groups configuration, specify the disk group names, the disk
+In the ASM disk group configuration, specify the disk group names, the disk
 names, and the associated block devices (the actual devices, not partitions) in a
 valid JSON format.
 
@@ -1218,7 +1218,7 @@ name defaults to `ask_disk_config.json`. Alternatively, pass the file content di
 as a JSON using `--ora-asm-disks-json` parameter. If both are present, 
 `--ora-asm-disks-json` takes precedence.
 
-The following example shows a properly formatted JSON ASM disk groups configuration file:
+The following example shows a properly formatted JSON ASM disk group configuration file:
 
 ```json
 [
@@ -1664,7 +1664,7 @@ RECO</td>
 <td>Default disk group for FRA files for initial database.</td>
 </tr>
 <tr>
-<td>ASM disk groups configuration</td>
+<td>ASM disk group configuration</td>
 <td><p><pre>
 ORA_ASM_DISKS
 --ora-asm-disks
@@ -1672,17 +1672,17 @@ ORA_ASM_DISKS
 <td>user defined<br>
 asm_disk_config.json</td>
 <td>Name of an ASM configuration file that contains ASM disk groups definitions in
-valid JSON format. See <a href="#asm-disk-groups-configuration">ASM disk groups configuration</a>.</td>
+valid JSON format. See <a href="#asm-disk-group-configuration">ASM disk group configuration</a>.</td>
 </tr>
 <tr>
-<td>ASM disk groups configuration</td>
+<td>ASM disk group configuration</td>
 <td><p><pre>
 ORA_ASM_DISKS_JSON
 --ora-asm-disks-json
 </pre></p></td>
 <td>user defined<br></td>
 <td>ASM disk groups definition in a valid JSON format. 
-See <a href="#asm-disk-groups-configuration">ASM disk groups configuration</a>.</td>
+See <a href="#asm-disk-group-configuration">ASM disk group configuration</a>.</td>
 </tr>
 </tbody>
 </table>

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -778,9 +778,17 @@ if [[ ! -f "$ORA_DATA_MOUNTS" && -z "$ORA_DATA_MOUNTS_JSON" ]]; then
   exit 2
 fi
 
+if [[ -f "$ORA_DATA_MOUNTS" && -n "$ORA_DATA_MOUNTS_JSON" ]]; then
+  echo "WARNING: ignoring --ora-data-mounts because --ora-data-mounts-json is specified"
+fi
+
 if [[ ! -f "$ORA_ASM_DISKS" && -z "$ORA_ASM_DISKS_JSON" ]]; then
   echo "Please specify --ora-asm-disks or --ora-asm-disks-json"
   exit 2
+fi
+
+if [[ -f "$ORA_ASM_DISKS" && -n "$ORA_ASM_DISKS_JSON" ]]; then
+  echo "WARNING: ignoring --ora-asm-disks because --ora-asm-disks-json is specified"
 fi
 
 # if the hostgroup is not the default then error out when there is no corresponding group_vars/var.yml file

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -960,10 +960,10 @@ ANSIBLE_PARAMS="-i ${INVENTORY_FILE} ${ANSIBLE_PARAMS}"
 ANSIBLE_EXTRA_PARAMS="${*}"
 
 if [[ -n "${ORA_ASM_DISKS_JSON}" ]]; then
-  ANSIBLE_EXTRA_PARAMS=${ANSIBLE_EXTRA_PARAMS}" -e '{\"asm_disk_input\": ${ORA_ASM_DISKS_JSON}}'"
+  ANSIBLE_EXTRA_PARAMS="${ANSIBLE_EXTRA_PARAMS} -e '{\"asm_disk_input\":${ORA_ASM_DISKS_JSON}}'"
 fi
 if [[ -n "${ORA_DATA_MOUNTS_JSON}" ]]; then
-  ANSIBLE_EXTRA_PARAMS=${ANSIBLE_EXTRA_PARAMS}" -e '{\"data_mounts_input\": ${ORA_DATA_MOUNTS_JSON}}'"
+  ANSIBLE_EXTRA_PARAMS="${ANSIBLE_EXTRA_PARAMS} -e '{\"data_mounts_input\":${ORA_DATA_MOUNTS_JSON}}'"
 fi
 
 echo "Ansible params: ${ANSIBLE_EXTRA_PARAMS}"


### PR DESCRIPTION
## Change Description:
Add options to `install-oracle.sh` to pass configurations from `data_mounts_config.json`, `asm_disk_config.json`, and `cluster-config.json` directly in CLI.

## Solution Overview:
Added support for new options: `--ora-data-mounts-json`, `--ora-asm-disks-json`, and `--cluster-config-json`. All are optional without default values. If they are provided, corresponding JSON files are ignored. First two of the new parameters are passed to `ansible-playbook` via `--extra-vars`.

## Test Commands:
```
time ./install-oracle.sh \
   --ora-swlib-bucket gs://bucket-name/19c \
   --backup-dest "+RECO" \
   --ora-swlib-path /u02/swlib/ \
   --ora-swlib-type gcs \
   --ora-asm-disks-json '[ { "diskgroup": "DATA", "disks": [ { "blk_device": "/dev/sdd", "name": "DATA1" } ] }, { "diskgroup": "RECO", "disks": [ { "blk_device": "/dev/sde", "name": "RECO1" } ] } ]' \
   --ora-data-mounts-json '[ { "purpose": "software", "blk_device": "/dev/sdb", "name": "u01", "fstype": "xfs", "mount_point": "/u01", "mount_opts": "nofail" }, { "purpose": "diag", "blk_device": "/dev/sdc", "name": "u02", "fstype": "xfs", "mount_point": "/u02", "mount_opts": "nofail" } ]' \
   --instance-ip-addr $IP_ADDRESS \
   --instance-hostname $HOST_NAME \
   --allow-install-on-vm
```

### Test 1: details:
Tested with OL8 and 19c. Full output: https://gist.github.com/pythianakhmadeev/d4ad62a9848bf609a5132c92a9b81029

### Test 2: details:
Validated `--cluster-config-json` parsing. Full output: https://gist.github.com/pythianakhmadeev/ffa4ce4ade395ed4468e9a1eef9b9ba5

## Expected Results:
Configuration from CLI is used correctly.