### PR TITLE
Fix issue with snapshot controlfile location; Formatting adjustments and RMAN script standardization

### DIFF
--- a/roles/db-backups/templates/rman_arch_backup.sh.j2
+++ b/roles/db-backups/templates/rman_arch_backup.sh.j2
@@ -4,16 +4,16 @@
 #
 # Variables
 #
-ora_inst_name=${1}
-arch_redundancy=${2}
-arch_day_online=${3}
+ora_inst_name=${1}                       # Instance name-- should match /etc/oratab
+arch_redundancy=${2}                     # Archivelog redundancy
+arch_day_online=${3}                     # Number of days to keep
 ts="date +%Y-%m-%d_%H-%M-%S"             # Timestamp format
 start_ts="$($ts)"                        # Start timestamp
 log_dir="{{ logs_dir }}"                 # A directory for the logs
 type="ARCH"                              # Type is archivelog backup
 conn_str="{% if oracle_ver == "11.2.0.4.0" %}/{% else %}/ AS SYSBACKUP{% endif %}" # Oracle connection string
 backup_dest="{{ backup_dest }}"          # Backup destination path
-reco_diskgroup="+{{ reco_diskgroup }}"   # Fast recovery area diskgroup
+fra_dest="{{ reco_diskgroup }}"          # Fast recovery area location
 export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
 #
 if [[ $# -ne 3 ]]; then
@@ -21,16 +21,6 @@ if [[ $# -ne 3 ]]; then
   exit 1
 fi
 
-#
-# Set the Oracle env
-#
-export ORACLE_SID="${ora_inst_name}"
-source oraenv <<< "${ora_inst_name}" > /dev/null 2>&1
-#
-# We can now build the output file and logfile names
-#
-outfile="${log_dir}/rman_${start_ts}_${type}.out"
-logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
 # Check if $log_dir exists; if not, we create it
 #
@@ -41,29 +31,47 @@ if [[ ! -d "${log_dir}" ]]; then
     printf "\n\t%s\n\n" "ERROR -- $($ts) -- Impossible to create ${log_dir}; we wont be able to log this backup."
   fi
 fi
-if [[ $backup_dest == "/"* ]]; then
+# If FRA is not a file system, add the ASM "+" sign (if not already added)
+if [[ "${fra_dest:0:1}" != "/" && "${fra_dest:0:1}" != "+" ]]; then
+  fra_dest="+${fra_dest}"
+fi
+if [[ "${backup_dest:0:1}" == "/" ]]; then
   # Filesystem destination
   autobackup_format="${backup_dest}/${ora_inst_name}_%F"
   channel_format="${backup_dest}/${ora_inst_name}_${type}_level_${rman_level}_%U"
-  reco_diskgroup="${reco_diskgroup#+}"
 else
-  # ASM destination;  no need for format specifiers
+  # ASM destination, no need for format specifiers; Add the ASM "+" sign (if not already added)
+  if [[ "${backup_dest:0:1}" != "+" ]]; then
+    backup_dest="+${backup_dest}"
+  fi
   autobackup_format="${backup_dest}"
   channel_format="${backup_dest}"
 fi
 #
-# Do the backup
+# We can now build the output file and log file names
 #
-if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
+outfile="${log_dir}/rman_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${start_ts}_${type}.log"
+#
+# Set the Oracle env
+#
+export ORACLE_SID="${ora_inst_name}"
+source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1
+#
+# RMAN backup
+#
+if "${ORACLE_HOME}/bin/rman" >>"${outfile}" <<EOF
   set echo on
   spool log to '${logfile}'
   connect target '${conn_str}'
 
   configure controlfile autobackup on;
   configure device type disk parallelism 4;
+
   configure controlfile autobackup format for device type disk to '${autobackup_format}';
   configure channel device type disk format '${channel_format}';
-  configure snapshot controlfile name to '${reco_diskgroup}/snapcf_${ora_inst_name}.f';
+  configure snapshot controlfile name to '${fra_dest}/snapcf_${ora_inst_name}.f';
+
   configure archivelog deletion policy to backed up ${arch_redundancy} times to disk;
   run {
     crosscheck archivelog all;
@@ -73,7 +81,7 @@ if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
   spool log off
 EOF
 #
-# Return code management
+# Success or error output with the name of the logfile
 #
 then
   printf "\n\t%s\n" "INFO -- $($ts) -- ${type} Level ${rman_level} of instance ${ora_inst_name} has been completed successfully."

--- a/roles/db-backups/templates/rman_full_backup.sh.j2
+++ b/roles/db-backups/templates/rman_full_backup.sh.j2
@@ -11,7 +11,7 @@ start_ts="$($ts)"                        # Start timestamp
 log_dir="{{ logs_dir }}"                 # A directory for the logs
 conn_str="{% if oracle_ver == "11.2.0.4.0" %}/{% else %}/ AS SYSBACKUP{% endif %}" # Oracle connection string
 backup_dest="{{ backup_dest }}"          # Backup destination path
-reco_diskgroup="+{{ reco_diskgroup }}"   # Fast recovery area diskgroup
+fra_dest="{{ reco_diskgroup }}"          # Fast recovery area location
 export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
 #
 if [[ $# -ne 4 ]]; then
@@ -19,7 +19,7 @@ if [[ $# -ne 4 ]]; then
   exit 1
 fi
 #
-# A tag for the logfile and output file depending on the backup level
+# A tag for the log file and output file depending on the backup level
 #
 if [[ "${rman_level}" = "0" ]]; then
   type="FULL"                            # Full backup
@@ -36,30 +36,36 @@ if [[ ! -d "${log_dir}" ]]; then
     printf "\n\t%s\n\n" "ERROR -- $($ts) -- Impossible to create ${log_dir}; we wont be able to log this backup."
   fi
 fi
-if [[ $backup_dest == "/"* ]]; then
+# If FRA is not a file system, add the ASM "+" sign (if not already added)
+if [[ "${fra_dest:0:1}" != "/" && "${fra_dest:0:1}" != "+" ]]; then
+  fra_dest="+${fra_dest}"
+fi
+if [[ "${backup_dest:0:1}" == "/" ]]; then
   # Filesystem destination
   autobackup_format="${backup_dest}/${ora_inst_name}_%F"
   channel_format="${backup_dest}/${ora_inst_name}_${type}_level_${rman_level}_%U"
-  reco_diskgroup="${reco_diskgroup#+}"
 else
-  # ASM destination;  no need for format specifiers
+  # ASM destination, no need for format specifiers; Add the ASM "+" sign (if not already added)
+  if [[ "${backup_dest:0:1}" != "+" ]]; then
+    backup_dest="+${backup_dest}"
+  fi
   autobackup_format="${backup_dest}"
   channel_format="${backup_dest}"
 fi
 #
-# We can now build the output file and logfile names
+# We can now build the output file and log file names
 #
 outfile="${log_dir}/rman_${start_ts}_${type}.out"
 logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
-# Set the oracle env
+# Set the Oracle env
 #
 export ORACLE_SID="${ora_inst_name}"
-source oraenv <<< "${ora_inst_name}" > /dev/null 2>&1
+source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1
 #
 # RMAN backup
 #
-if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
+if "${ORACLE_HOME}/bin/rman" >>"${outfile}" <<EOF
   set echo on
   spool log to '${logfile}'
   connect target '${conn_str}'
@@ -69,7 +75,7 @@ if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
 
   configure controlfile autobackup format for device type disk to '${autobackup_format}';
   configure channel device type disk format '${channel_format}';
-  configure snapshot controlfile name to '${reco_diskgroup}/snapcf_${ora_inst_name}.f';
+  configure snapshot controlfile name to '${fra_dest}/snapcf_${ora_inst_name}.f';
 
   configure archivelog deletion policy to backed up ${arch_redundancy} times to disk;
   configure retention policy to redundancy ${retention_redundancy};


### PR DESCRIPTION
## Change Description:

Fix issue with snapshot controlfile location. Currently, the RMAN backup scripts will generate an error if the toolkit parameters specify ASM (even if by default) for the RECO_DISKGROUP, but a file system for the backup location.

In such a case, the RMAN backup logfile will show:

```
...

RMAN>   configure snapshot controlfile name to 'RECO/snapcf_ORCL.f';
new RMAN configuration parameters:
CONFIGURE SNAPSHOT CONTROLFILE NAME TO 'RECO/snapcf_ORCL.f';
new RMAN configuration parameters are successfully stored

...

RMAN-00571: ===========================================================
RMAN-00569: =============== ERROR MESSAGE STACK FOLLOWS ===============
RMAN-00571: ===========================================================
RMAN-03002: failure of backup plus archivelog command at 02/07/2025 09:56:02

RMAN-03009: failure of backup command on ORA_DISK_2 channel at 02/07/2025 09:55:59
ORA-01580: error creating control backup file /u01/app/oracle/product/19.3.0/dbhome_1/dbs/RECO/snapcf_ORCL.f
ORA-27040: file create error, unable to create file
Linux-x86_64 Error: 2: No such file or directory
Additional information: 1

...
```

As well as fixing this issue, this change includes some standardization of the RMAN FULL and ARCH backup scripts between each other. And some minor shell script formatting adjustments.

## Solution Overview:

The significant part of this change is fixing the issue with the snapshot controlfile when a file system based backup location is specified, while the RECO_DISKGROUP is in ASM.

Relevant script addition section:

```bash
# If FRA is not a file system, add the ASM "+" sign (if not already added)
if [[ "${fra_dest:0:1}" != "/" && "${fra_dest:0:1}" != "+" ]]; then
  fra_dest="+${fra_dest}"
fi
```

Also, order of major sections (such as when the log files are defined, when the environment is setup using oraenv, etc) differ between the two backup scripts. Adjusted to bring the order of sections in alignment between the two scripts for consistency and easier comprehension.

Finally, applied minor formatting and linting adjustments to both scripts.

## Test Commands:

### Test Prep:

Create database, using either a file system, or ASM backup location. Example:

```bash
export INSTANCE_IP_ADDR=${INSTANCE_IP_ADDR:-10.2.80.21}

./cleanup-oracle.sh \
  --ora-version 19 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --yes-i-am-sure

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest /u01/backups \
  --no-patch
```

### Test 1: Test backups and snapshot controlfile location with a file system backup location:

Remove the backup scripts and existing log files on the **managed host** between tests using:

```bash
rm ~oracle/scripts/rman_*_backup.sh
rm ~oracle/logs/rman*.log
rm ~oracle/logs/rman*.out
```

Test with the backup destination on a file system. Run from the **Ansible control node**:

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest /u01/backups \
  --config-db
```

After test, verify from the RMAN backup logs on the **managed host**:

```bash
grep 'CONFIGURE CONTROLFILE AUTOBACKUP FORMAT' *.log
```

### Test 2: Test backups and snapshot controlfile location with an ASM backup location:

Remove the backup scripts and existing log files on the **managed host** between tests using:

```bash
rm ~oracle/scripts/rman_*_backup.sh
rm ~oracle/logs/rman*.log
rm ~oracle/logs/rman*.out
```

Test with the backup destination set to an ASM disk group. Run from the **Ansible control node**:

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest +RECO \
  --config-db
```

After test, verify from the RMAN backup logs on the **managed host**:

```bash
grep 'CONFIGURE CONTROLFILE AUTOBACKUP FORMAT' *.log
```

## Additional end-to-end test run results:

Testing with Oracle Free Edition (which currently doesn't support ASM at all and instead stores datafiles, the FRA, and backups on a Linux file system):

```bash
export INSTANCE_IP_ADDR=10.2.80.41

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition free \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition \
  --backup-dest /opt/oracle/fast_recovery_area/FREE
```

Resulting log file:

- [oratk-90: Full 23ai Free Edition test with FS FRA and backups](https://gist.github.com/simonpane/289537508b2ca79ed1622ca712af3d56)

Testing a normal Enterprise Edition install with backups to a Linux file system:

```bash
export INSTANCE_IP_ADDR=10.2.80.26

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest /u01/backups
```

Resulting log file:

- [oratk-90: Full 19c EE test with ASM FRA and FS backups](https://gist.github.com/simonpane/2b1d33ab85ce4ae0dfb44d7401f7aa63)

Testing a normal Enterprise Edition install with backups to an ASM disk group:

```bash
export INSTANCE_IP_ADDR=10.2.80.28

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest +RECO
```

Resulting log file:

- [oratk-90: Full 19c EE test with ASM FRA and ASM backups](https://gist.github.com/simonpane/7232d2223794e94ccaa41b22fc175c41)
