### PR TITLE
Set CV_ASSUME_DISTID for RAC DBCA runs

### DIFF
--- a/roles/db-create/tasks/rac-db-create.yml
+++ b/roles/db-create/tasks/rac-db-create.yml
@@ -89,6 +89,14 @@
     group: "{{ oracle_group }}"
   tags: rac-db-create
 
+- name: rac-db-create | Set CV_ASSUME_DISTID to OEL7 when installing on RHEL8  # MOS Note 3017836.1
+  set_fact:
+    cv_distid: "{{ 'OEL7' if ansible_os_family == 'RedHat'
+                           and (ansible_distribution_major_version | int) >= 8
+                           and (oracle_ver_base | float) <= 19.3
+                           else '' }}"
+  tags: rac-db-create
+
 - name: rac-db-create | Create DBCA response file
   become: true
   become_user: root
@@ -105,6 +113,8 @@
     - name: rac-db-create | Run DBCA
       become: true
       become_user: "{{ oracle_user }}"
+      environment:
+        CV_ASSUME_DISTID: "{{ cv_distid }}"
       shell: |
         set -o pipefail
         export PATH={{ oracle_home }}/bin:${PATH}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin


### PR DESCRIPTION
# Change description
Set CV_ASSUME_DISTID for RAC DBCA runs

# Solution overview

In RAC environments, DBCA actually runs the cluster verification utility.  And in early 19c releases, it has the same issue as the CVU runs during grid installs (#183).  MOS note reference: 3017836.1

# Test command

```
bash install-oracle.sh   --instance-ssh-key '~/.ssh/ansible'   --ora-swlib-bucket gs://bucket  \
 --ora-swlib-type gcs   --ora-swlib-path /swlib   --ora-version 19    --backup-dest /u01/backups \
  --cluster-type RAC   --cluster-config cluster_config.json   --ora-asm-disks asm_disk.json   \
 --ora-data-mounts data_mounts.json   --ora-data-diskgroup DATA   --ora-db-name orcl   \
 --ora-db-container false   --no-patch --ora-reco-diskgroup DATA
```

# Test output

Before the change:

```
TASK [db-create : rac-db-create | Run DBCA] ************************************
fatal: [mfielding-ora122-node1]: FAILED! => {"changed": true, "cmd": "set -o pipefail\nexport PATH=/u01/app/oracle/product/19.3.0/dbhome_1/bin:${PATH}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin\necho -e \"$(/usr/local/bin/pwgen.sh 16 'AaBbCc12345')\\n$(/usr/local/bin/pwgen.sh 16 'AaBbCc12345')\\n$(/usr/local/bin/pwgen.sh 16 'AaBbCc12345')\" | sh /swlib/dbca_orcl.rsp.sh\n", "delta": "0:00:17.609520", "end": "2025-02-14 20:35:21.711605", "failed_when_result": true, "msg": "non-zero return code", "rc": 255, "start": "2025-02-14 20:35:04.102085", "stderr": "", "stderr_lines": [], "stdout": "[WARNING] [INS-06005] Unable to get SSH connectivity details.\n   CAUSE: An unexpected error occured while getting SSH connectivity details across the selected nodes.\n   ACTION: Refer to the logs for more details or contact Oracle Support Services.\n   SUMMARY:\n       - java.lang.NullPointerException\n[WARNING] [INS-08109] Unexpected error occurred while validating inputs at state 'ConfigurationParams'.\n   CAUSE: No additional information available.\n   ACTION: Contact Oracle Support Services or refer to the software manual.\n   SUMMARY:\n       - Could not initialize class oracle.ops.verification.framework.storage.StorageUtil", "stdout_lines": ["[WARNING] [INS-06005] Unable to get SSH connectivity details.", "   CAUSE: An unexpected error occured while getting SSH connectivity details across the selected nodes.", "   ACTION: Refer to the logs for more details or contact Oracle Support Services.", "   SUMMARY:", "       - java.lang.NullPointerException", "[WARNING] [INS-08109] Unexpected error occurred while validating inputs at state 'ConfigurationParams'.", "   CAUSE: No additional information available.", "   ACTION: Contact Oracle Support Services or refer to the software manual.", "   SUMMARY:", "       - Could not initialize class oracle.ops.verification.framework.storage.StorageUtil"]}
```

https://gist.github.com/mfielding/72e2a0a31dfb9a8f1208b448770fb64d

After the change, DBCA succeeds

https://gist.github.com/mfielding/dbcfc1d50608c19c793b6864ab46679b

(Yes there is an error enabling archivelog;  I'm working on that!)