### PR TITLE
Fix RAC status check on archivelog_mode.sh.j2

### DIFF
--- a/roles/db-adjustements/templates/archivelog_mode.sh.j2
+++ b/roles/db-adjustements/templates/archivelog_mode.sh.j2
@@ -2,7 +2,7 @@ source oraenv <<< {{ oracle_sid }}
 
 srvctl_status="$(srvctl status database -d {{ db_name }})"
 
-if [[ "${srvctl_status}" == "Database is running." ]]; then
+if [[ "${srvctl_status}" == "is running" ]]; then
   srvctl stop db -d {{ db_name }} -o immediate
 else
   echo "shutdown immediate" | sqlplus -s -L / as sysdba

--- a/roles/db-adjustements/templates/archivelog_mode.sh.j2
+++ b/roles/db-adjustements/templates/archivelog_mode.sh.j2
@@ -2,7 +2,7 @@ source oraenv <<< {{ oracle_sid }}
 
 srvctl_status="$(srvctl status database -d {{ db_name }})"
 
-if [[ "${srvctl_status}" == "is running" ]]; then
+if [[ "${srvctl_status}" =~ "is running" ]]; then
   srvctl stop db -d {{ db_name }} -o immediate
 else
   echo "shutdown immediate" | sqlplus -s -L / as sysdba


### PR DESCRIPTION
# Change Description

A small update to the match string in `archivelog_mode.sh.j2` to catch RAC cases, but still to fail when Oracle Restart isn't configured (like free edition).

# Solution Overview

The update in https://github.com/google/oracle-toolkit/commit/46af82549aeac5ab84afaf6d008646938aba239e to handle free edition changed the logic to run a `srvctl status database` command and looks for the string `Database is running.`.  On a RAC system however, output looks like this:

```
$ srvctl status database -d orcl
Instance orcl1 is running on node node1
Instance orcl2 is running on node node2
```

Therefore the string doesn't match, and the script shuts down via sqlplus.  Since the second node is still running, the archivelog change fails with `ORA-01126: database must be mounted in this instance and not open in any instance`.

# Test results

Before:

https://gist.github.com/mfielding/e2aff60c771bf29b3741e11fed936eed

```
ORACLE_SID = [oracle] ? The Oracle base has been set to /u01/app/oracle\nDatabase closed.
Database dismounted.
ORACLE instance shut down.
ORACLE instance started.

Total System Global Area 7633630640 bytes
Fixed Size\t\t    8914352 bytes
Variable Size\t\t 1358954496 bytes
Database Buffers\t 6257901568 bytes
Redo Buffers\t\t    7860224 bytes
Database mounted.
alter database archivelog
*
ERROR at line 1:
ORA-01126: database must be mounted in this instance and not open in any
instance
```

After:

https://gist.github.com/mfielding/77605cd8b36b503f2bc139443f927410
