### PR TITLE
Force pkcs1 key generation to make Oracle CVU happy

### DIFF
--- a/roles/ssh-setup/tasks/main.yml
+++ b/roles/ssh-setup/tasks/main.yml
@@ -32,6 +32,8 @@
     mode: u=rw,go=
     owner: "{{ ssh_user }}"
     group: "{{ user_group }}"
+    private_key_format: "pkcs1"
+    backend: "cryptography"
   register: ssh_key
   tags: ssh-keys
 


### PR DESCRIPTION
# Change Description

Force SSH key generation in PEM format for compatibility with the old JCH framework in cluvfy.

# Solution Overview

In OpenSSH 7.8, the default private key format changed from the standard PEM format to an OpenSSH-specific one.  And Oracle 19c's CVU runs an old Java that doesn't recognize this format, causing private key checks to fail with `[INS-06005] Unable to get SSH connectivity details`.

https://jadaptive.com/java-ssh-library/java-ssh-and-the-new-openssh-private-key-format/
MOS note 2870317.1

The workaround is to force old-style PEM file creation, which in the Ansible wrapper, means using the `cryptography` backend with `pkcs1` key format.

This issue only happens in cluster installs that run CVU.

# Test results

Before:

```
[WARNING] [INS-06005] Unable to get SSH connectivity details.
   CAUSE: An unexpected error occured while getting SSH connectivity details across the selected nodes.
   ACTION: Refer to the logs for more details or contact Oracle Support Services.
   SUMMARY:
- java.lang.NullPointerException
```
https://gist.github.com/mfielding/907cbf5ea5b12fa9c777c7c2656c925e

After:

Success

https://gist.github.com/mfielding/77605cd8b36b503f2bc139443f927410
