### PR TITLE
Add `1MB` to Ansible fact `ansible_memtotal_mb` to account for rounding (down) errors

### DIFF
--- a/roles/hugepages/tasks/main.yml
+++ b/roles/hugepages/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: Update the vm.nr_hugepages sysctl value
   sysctl:
     name: "vm.nr_hugepages"
-    value: "{{ ((ansible_memtotal_mb * (ram_pct_used | int) / 100) * 1024 / (v_Hugepagesize.stdout | int)) | round(0,'ceil') | int }}"
+    value: "{{ (((ansible_memtotal_mb + 1) * (ram_pct_used | int) / 100) * 1024 / (v_Hugepagesize.stdout | int)) | round(0,'ceil') | int }}"
     state: present
     sysctl_set: true
     reload: true

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -132,7 +132,7 @@ sysctl_param_values:
   - parameter: "kernel.sem"
     value: "250 32000 100 128"
   - parameter: "kernel.shmmax"
-    value: "{{ (ansible_memtotal_mb * 524288) | round(0,'ceil') | int }}"  # (MB->Bytes)/2: 1024*1024/2 = 52488
+    value: "{{ ((ansible_memtotal_mb + 1) * 524288) | round(0, 'ceil') | int }}"  # (MB->Bytes)/2: 1024*1024/2 = 524288
   - parameter: "kernel.shmmni"
     value: 4096
   - parameter: "kernel.panic_on_oops"

--- a/roles/ora-host/tasks/kernel_parameters.yml
+++ b/roles/ora-host/tasks/kernel_parameters.yml
@@ -34,15 +34,15 @@
 - name: kernel_parameters | Update the shmall sysctl value (if less than "ram_pct_used" the size of physical memory)
   sysctl:
     name: "kernel.shmall"
-    value: "{{ (ansible_memtotal_mb * 256 * (ram_pct_used | int) / 100) | round(0,'ceil') | int }}"  # (MB->bytes)/pagesize: 1024*1024/4096=256
+    value: "{{ ((ansible_memtotal_mb + 1) * 256 * (ram_pct_used | int) / 100) | round(0, 'ceil') | int }}"  # (MB->bytes)/pagesize: 1024*1024/4096=256
     state: present
     sysctl_set: true
     reload: true
     ignoreerrors: true
   vars:
     current_shmall: "{{ (sysctl_settings | selectattr('parameter', 'equalto', 'kernel.shmall') | map(attribute='value') | first) | default('0') }}"
-    calculated_shmall: "{{ (ansible_memtotal_mb * 256 * (ram_pct_used | int) / 100) | round(0,'ceil') }}"
-  when: current_shmall | int < calculated_shmall | int or current_shmall | int > (ansible_memtotal_mb * 256)  # Must cast to int at this stage for Ansible 2.9
+    calculated_shmall: "{{ ((ansible_memtotal_mb + 1) * 256 * (ram_pct_used | int) / 100) | round(0, 'ceil') }}"
+  when: current_shmall | int < calculated_shmall | int or current_shmall | int > ((ansible_memtotal_mb + 1 ) * 256)  # Must cast to int at this stage for Ansible 2.9
 
 - name: kernel_parameters | Update other sysctl values
   sysctl:


### PR DESCRIPTION
Logic to calculate `shmmax` and `shmall` in the `ora-host` role is potentially leading to warnings in the OUI log file due to rounding errors from the `ansible_memtotal_mb` variable (which is used for the calculation of these values).

Sample output from the **runInstaller** log file from a `n1-standard-1` VM:

```
INFO:  [Feb 18, 2025 12:25:47 PM] *********************************************
INFO:  [Feb 18, 2025 12:25:47 PM] OS Kernel Parameter: shmmax: This is a prerequisite condition to test whether the OS kernel parameter "shmmax" is properly set.
INFO:  [Feb 18, 2025 12:25:47 PM] Severity:IGNORABLE
INFO:  [Feb 18, 2025 12:25:47 PM] OverallStatus:VERIFICATION_FAILED
INFO:  [Feb 18, 2025 12:25:47 PM] -----------------------------------------------
INFO:  [Feb 18, 2025 12:25:47 PM] Verification Result for Node:rhel7-db-001
INFO:  [Feb 18, 2025 12:25:47 PM] Expected Value:1852854272
INFO:  [Feb 18, 2025 12:25:47 PM] Actual Value:Current=1852833792; Configured=1852833792
INFO:  [Feb 18, 2025 12:25:47 PM] Error Message:PRVG-1205 : OS kernel parameter "shmmax" does not have expected current value on node "rhel7-db-001" [Expected = "1852854272" ; Current = "1852833792"; Configured = "1852833792"].
INFO:  [Feb 18, 2025 12:25:47 PM] Cause: A check of the current value for an OS kernel parameter did not find the expected value.
INFO:  [Feb 18, 2025 12:25:47 PM] Action: Modify the kernel parameter current value to meet the requirement.
INFO:  [Feb 18, 2025 12:25:47 PM] Error Message:PRVG-1201 : OS kernel parameter "shmmax" does not have expected configured value on node "rhel7-db-001" [Expected = "1852854272" ; Current = "1852833792"; Configured = "1852833792"].
INFO:  [Feb 18, 2025 12:25:47 PM] Cause: A check of the configured value for an OS kernel parameter did not find the expected value.
INFO:  [Feb 18, 2025 12:25:47 PM] Action: Modify the kernel parameter configured value to meet the requirement.
INFO:  [Feb 18, 2025 12:25:47 PM] -----------------------------------------------
INFO:  [Feb 18, 2025 12:25:47 PM] *********************************************
```

Math: `(1852854272-1852833792)/1024=20KB` meaning chosen size is just `20KB` too small

---

Additional testing and findings (from a different `c4-standard-4` shape system):

- Ansible reported memory: `"ansible_memtotal_mb": 14975`
- Output from `free -m`: `14975`
- So Ansible is reporting the same as **free** with the `-m` option
- But from man free, the output is "_Display the amount of memory in mebibytes_".
- Confirmed with: `free --mega`: `15702`
- Finally, `free -b`: `15702900736`

Ansible is reporting the `MiB (mebibyte)` values and binary calculations are indeed used in the playbook calculations.  So it doesn't seem to be a megabyte vs mebibyte issue.  (That would also cause a much larger discrepancy.)

Appears to be a `round` vs `floor` vs `ceil` issue as `15702900736/1000/1000=15702.90` which **free** seems to be using a `floor` function on.  While `15702900736/1024/1024=14975.45` which could be a `round` or `floor` function.

---

Conclusion is that there could be a **1 megabyte (1024*1024)** rounding issue when using `ansible_memtotal_mb`.  Probably little harm to simply add 1 to calculations using the `ansible_memtotal_mb` Ansible fact.

- Tested against a  `n1-standard-1` VM with the toolkit code base from before this change - runInstaller logfile error REPRODUCED.
- Tested against a  `n1-standard-1` VM with this change - NO WARNINGS related to `shmmax`.