### PR TITLE
Remove 19c base zip files from log4j list

### DIFF
--- a/roles/patch-vulns/tasks/main.yml
+++ b/roles/patch-vulns/tasks/main.yml
@@ -31,6 +31,4 @@
     - "{{ oracle_home }}/md/property_graph/pgx"
     - "{{ oracle_home }}/.patch_storage/34419443_Oct_14_2022_05_25_14/files/md/property_graph.zip"
     - "{{ oracle_home }}/.patch_storage/34419443_Oct_14_2022_05_25_14/files/suptools/tfa.zip"
-    - "{{ swlib_path }}/V982063-01.zip"
-    - "{{ swlib_path }}/V982068-01.zip"
   tags: patch-vulns


### PR DESCRIPTION
# Change description

Remove the 19c base install zip files from the log4j removal list, allowing them to be persisted in swlib.

# Solution overview

As part of log4j protection, the `patch-vulns` playbook removes files known to have log4j vulnerabilities, specifically old TFA and graph functionality, as well as associated patches.

While technically the zip file contains the vulnerable components, we get little benefit from removing the archive, as, on the next run, it gets re-downloaded from the upstream location.  So to avoid the unnecessary recopying, this change will leave the archives in place.

# Test results

None due to the triviality, but will let the prow tests run on this.