### PR TITLE
Refactor ohasd shutdown in cleanup playbook

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -15,9 +15,7 @@
 ---
 - name: Shut down RAC clusterware
   # Regrettably we can't use ansible's service module, as Oracle's init scripts don't report status
-  shell: service ohasd stop
-  args:
-    warn: false
+  shell: /etc/init.d/init.ohasd stop
   become: true
   register: service_stop
   ignore_errors: true


### PR DESCRIPTION
# Change description

Update the ohasd shutdown command to call the /etc/init.d command directly (as the systemd unit does anyway).  It allows us to remove the `warn: false` clause that raises an error in Ansible 2.14+ (https://github.com/ansible/ansible/blob/v2.11.0/changelogs/CHANGELOG-v2.11.rst#deprecated-features)

## Solution overview

RAC clusterware has a number of checks and restarts that make it difficult to remove while running.  Therefore we first attempt a clean shutdown at the very beginning of the cleanup process.  RAC's `ohasd` has a systemctl unit, but it simply executes `/etc/init.d/init.ohasd`, discarding output, so doesn't work well with ansible's systemd module.  To avoid an unnecessary warning, we set `warn: false` in the `command` that shuts down the service.  But in Ansible 2.14+, this results in an error.  So to maintain backwards compatibility, here we change the command to call the `/etc/init.d` script directly.  (FWIW, the original list of warning is in https://github.com/ansible/ansible/commit/ab8490d00389269455db2e781314f4015cdb3885, and /etc/init.d isn't on the list)

## Test results

Before:

```
TASK [Verify that Ansible on control node meets the version requirements] ******
ok: [mfielding-ora122-node1] => {
    "changed": false,
    "msg": "Ansible version is 2.16.3, continuing"
}
ok: [mfielding-ora122-node2] => {
    "changed": false,
    "msg": "Ansible version is 2.16.3, continuing"
}
TASK [brute-ora-cleanup : Shut down RAC clusterware] ***************************
fatal: [mfielding-ora122-node2]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, arg
v, chdir, creates, executable, expand_argument_vars, removes, stdin, stdin_add_newline, strip_empty_ends."}
...ignoring
fatal: [mfielding-ora122-node1]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, arg
v, chdir, creates, executable, expand_argument_vars, removes, stdin, stdin_add_newline, strip_empty_ends."}
...ignoring
```

After:

```
TASK [brute-ora-cleanup : Shut down RAC clusterware] ***************************
changed: [mfielding-ora122-node2]
changed: [mfielding-ora122-node1]
```

