### PR TITLE
Ansible key-order fixes for `block` module tasks

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -53,6 +53,10 @@
     - not free_edition
 
 - name: Free Edition cleanup steps
+  become: true
+  become_user: root
+  when: free_edition
+  ignore_errors: true
   block:
     - include_role:
         name: common
@@ -159,11 +163,6 @@
         - "/usr/share/licenses/oracle-database-preinstall-{{ free_edition_name }}"
         - "/var/log/oracle-database-free-{{ free_edition_name }}"
         - "/var/log/oracle-database-preinstall-{{ free_edition_name }}"
-
-  ignore_errors: true
-  become: true
-  become_user: root
-  when: free_edition
 
 - name: De-configure CRS (non-RAC)
   command: "{{ grid_home }}/perl/bin/perl -I {{ grid_home }}/perl/lib -I {{ grid_home }}/crs/install {{ grid_home }}/crs/install/roothas.pl -deconfig -force -verbose"
@@ -392,6 +391,14 @@
     tasks_from: populate-swap-partition-id.yml
 
 - name: Disable and remove swap
+  become: true
+  become_user: root
+  when:
+    - swap_blk_device is defined
+    - swap_partition_id is defined
+    - swap_blk_device|length > 0
+  ignore_errors: true
+  tags: remove-swap
   block:
     - name: Turn swap off
       command: "swapoff {{ swap_partition_id }}"
@@ -407,13 +414,6 @@
         path: /etc/fstab
         regexp: "^{{ swap_blk_device }}"
         state: absent
-  become: true
-  when:
-    - swap_blk_device is defined
-    - swap_partition_id is defined
-    - swap_blk_device|length > 0
-  ignore_errors: true
-  tags: remove-swap
 
 - name: Refresh kernel partition table view
   become: true

--- a/roles/db-create/tasks/rac-db-create.yml
+++ b/roles/db-create/tasks/rac-db-create.yml
@@ -177,6 +177,8 @@
 - name: rac-db-create | Blocks of tasks if release is not base
   vars:
     startup_upgrade: upgrade
+  when: oracle_rel != "base"
+  tags: rac-db-create,newdb-datapatch
   block:
     - name: rac-db-create | Set cluster_database to false
       shell: |
@@ -311,5 +313,3 @@
       become: true
       become_user: "{{ oracle_user }}"
       when: oracle_ver != '11.2.0.4.0'
-  when: oracle_rel != "base"
-  tags: rac-db-create,newdb-datapatch

--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -80,6 +80,7 @@
   tags: patch-grid,sw-unzip
 
 - name: (RDBMS) Get database role
+  tags: patch-grid,patch-rdbms
   block:
     - name: Get database role from sqlplus
       shell: |
@@ -98,7 +99,6 @@
     - name: Set boolean standby_db variable
       set_fact:
         standby_db: "{{ db_role.stdout is search('PHYSICAL STANDBY') | bool }}"
-  tags: patch-grid,patch-rdbms
 
 - name: (GI) Apply patch
   include_tasks: opatch_apply.yml

--- a/roles/patch/tasks/rac-opatch.yml
+++ b/roles/patch/tasks/rac-opatch.yml
@@ -44,6 +44,7 @@
   tags: rac-opatch
 
 - name: rac-opatch | If patch to apply then variable is true
+  tags: rac-opatch
   block:
     - name: check is apply is needed
       set_fact:
@@ -51,7 +52,6 @@
     - name: show the variable value
       debug:
         msg: "apply needed? - {{ apply_needed }}"
-  tags: rac-opatch
 
 - name: rac-opatch | GI opatch analyze output
   debug:

--- a/roles/swlib/tasks/main.yml
+++ b/roles/swlib/tasks/main.yml
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 ---
-- block:
+- name: swlib | setup
+  become: true
+  become_user: root
+  block:
     - name: swlib | Create swlib folder
       file:
         path: "{{ swlib_path }}"
@@ -28,8 +31,6 @@
     - name: swlib | gcsfuse mount
       include_tasks: gcsfuse.yml
       when: swlib_mount_type == "gcsfuse"
-  become: true
-  become_user: root
 
 - name: swlib | gcscopy
   include_tasks: gcscopy.yml


### PR DESCRIPTION
## Change Description:

Ansible lint key-order fixes for `block` modules (only) as per https://ansible.readthedocs.io/projects/lint/rules/key-order/

Also added the `become_user: root` key (with the associated `become: true`) for task `Disable and remove swap` in file `roles/brute-ora-cleanup/tasks/main.yml` for additional clarity, consistency with other tasks, and as a good practice.

No other functional changes to the toolkit - only key-order adjustments for a small handful of `block` module tasks.

## Test Commands:

```bash
export INSTANCE_IP_ADDR=${INSTANCE_IP_ADDR:-10.2.80.110}

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname db-server19c \
  --ora-version 19 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --backup-dest "+RECO" \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2"    ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --no-patch

./apply-patch.sh \
  --inventory-file inventory_files/inventory_db-server19c_ORCL \
  --ora-version 19 \
  --ora-release latest \
  --ora-swlib-bucket gs://BUCKET_NAME

./check-swlib.sh \
  --ora-version 19 \
  --ora-swlib-bucket gs://BUCKET_NAME

./cleanup-oracle.sh \
  --ora-version 19 \
  --inventory-file inventory_files/inventory_db-server19c_ORCL \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2"    ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --yes-i-am-sure
```

Test results: [oratk-88: Full test run output](https://gist.github.com/simonpane/ed475add5ca492e524c41e0f27984680)
