### PR TITLE
Adding fix for 18c Patching failing due to `rc=42 OPATCHAUTO-72043: Failed to create bundle patch object`

### DIFF
--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -39,6 +39,24 @@
   become: true
   become_user: root
 
+- name: Bug 31748584 resolution - MOS (Doc ID 2283767.1) Case3a
+  block:
+    - name: (GI) Remove existing OPatch directory
+      file:
+        path: "{{ grid_home }}/OPatch"
+        state: absent
+    
+    - name: (GI) Create empty OPatch directory
+      file:
+        path: "{{ grid_home }}/OPatch"
+        state: directory
+        mode: '0755'
+        owner: "{{ grid_user }}"
+        group: "{{ oracle_group }}"
+  become: true
+  become_user: root
+  tags: update-opatch-gi
+
 - name: (GI) Update OPatch
   unarchive:
     src: "{{ swlib_path }}/{{ item.patchfile }}"

--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -39,7 +39,7 @@
   become: true
   become_user: root
 
-- name: Bug 31748584 resolution - MOS (Doc ID 2283767.1) Case3a
+- name: Clean up old files in OPatch directory (MOS Doc ID 2283767.1, case 3a)
   block:
     - name: (GI) Remove existing OPatch directory
       file:


### PR DESCRIPTION
## Change Description:

During testing of the 18c patching process, we encountered a failure in the `TASK [patch : opatch_apply | Run OPatch analyze]` task.

```
OPATCHAUTO-72043: Patch collection failed.
OPATCHAUTO-72043: Failed to create bundle patch object.
OPATCHAUTO-72043: Please verify the patch supplied.
opatchauto failed with error code 42
```

Full Error gist [here](https://gist.github.com/simonpane/8e8b1e88967376f1afca0980f31a3e77)

## Solution Overview:

Upon investigation it was found that the opatch directory had old jar files as shown below:

```
[grid@ashishsharma-db-rhel7-yrif  +ASM  /u01/app/18.0.0/grid/OPatch/modules]$ ls -lrt
total 5088
-rw-r-----. 1 grid oinstall  213191 Jun  2  2018 com.oracle.glcm.patch.opatch-common-api-schema_13.9.3.0.jar
-rw-r-----. 1 grid oinstall   76989 Jun  2  2018 com.oracle.glcm.patch.opatch-common-api-interfaces_13.9.3.0.jar
-rw-r-----. 1 grid oinstall  206061 Jun  2  2018 com.oracle.glcm.patch.opatch-common-api_13.9.3.0.jar
-rw-r-----. 1 grid oinstall   52088 Jun  2  2018 com.oracle.glcm.patch.opatchauto-wallet_13.9.3.0.jar
drwxrwxr-x. 3 grid oinstall     199 Jun  3  2018 thirdparty
drwxr-x---. 2 grid oinstall      90 Jun  3  2018 oracle.rsa
drwxr-x---. 3 grid oinstall      22 Jun  3  2018 internal
-rw-r-----. 1 grid oinstall  106733 Oct  4 14:37 jaxb-api-2.2.3.jar
-rw-r-----. 1 grid oinstall  122370 Oct  4 14:43 javax.xml.bind.javax.xml.bind-api.jar
-rw-r-----. 1 grid oinstall   62983 Oct  4 14:43 javax.activation.javax.activation.jar
-rw-r-----. 1 grid oinstall 2052502 Oct  4 14:43 com.sun.xml.bind.jaxb-xjc.jar
-rw-r-----. 1 grid oinstall  134241 Oct  4 14:43 com.sun.xml.bind.jaxb-jxc.jar
-rw-r-----. 1 grid oinstall 1099277 Oct  4 14:43 com.sun.xml.bind.jaxb-impl.jar
-rw-r-----. 1 grid oinstall  255352 Oct  4 14:43 com.sun.xml.bind.jaxb-core.jar
-rw-r-----. 1 grid oinstall   68177 Oct  4 14:43 com.sun.org.apache.xml.internal.resolver.jar
-rw-r-----. 1 grid oinstall  244252 Oct  4 14:43 com.oracle.glcm.patch.opatch-common-api-schema_13.9.5.0.jar
-rw-r-----. 1 grid oinstall  102866 Oct  4 14:43 com.oracle.glcm.patch.opatch-common-api-interfaces_13.9.5.0.jar
-rw-r-----. 1 grid oinstall  324355 Oct  4 14:43 com.oracle.glcm.patch.opatch-common-api_13.9.5.0.jar
-rw-r-----. 1 grid oinstall   52091 Oct  4 14:43 com.oracle.glcm.patch.opatchauto-wallet_12.2.1.44.0.jar
drwxr-x---. 2 grid oinstall      27 Mar  3 21:28 oracle.pki
drwxr-x---. 2 grid oinstall     180 Mar  3 21:28 oracle.osdt
drwxr-x---. 2 grid oinstall      24 Mar  3 21:28 oracle.ldap
drwxr-x---. 2 grid oinstall     264 Mar  3 21:28 features
[grid@ashishsharma-db-rhel7-yrif  +ASM  /u01/app/18.0.0/grid/OPatch/modules]$

```
As per My Oracle Support Note 2283767.1, this is due to BUG [31748584 ](https://support.oracle.com/epmos/faces/BugDisplay?parent=DOCUMENT&sourceId=2283767.1&id=31748584)- OPATCHAUTO-72043: PATCH COLLECTION FAILED. OPATCHAUTO-72043: FAILED TO CREATE BUNDLE PATCH OBJECT. 

To fix this issue, a code block has been added to `roles/patch/tasks/main.yml` which removes the existing OPatch directory and creates an empty OPatch directory in grid home before the GI opatch patch is updated.

## Test Commands:

```
time ./apply-patch.sh \
--inventory-file inventory_files/inventory_ashishsharma-db-rhel7-yrif_ORCL \
--ora-version 18 \
--ora-release latest \
--ora-swlib-bucket gs://pythian-gto-oracle-software/18c
```

### Test Results:

Patching of 18c database completes successfully.
Full Output of patching is [here](https://gist.github.com/pythianasharma/52712d5bd140d825d2c409e09d003d3f)