### PR TITLE
Fix up asmcmd in 18c in addition to 12cR2

### DIFF
--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -211,6 +211,18 @@
   when: oracle_ver == '12.2.0.1.0'
   tags: rac-gi,rac-gi-install
 
+- name: rac-gi-install | Fix up asmcmd in 18c (MOS note 2748316.1)
+  become: yes
+  become_user: "{{ grid_user }}"
+  register: fixup_asmcmd
+  shell: "make -f ins_rdbms.mk client_sharedlib libasmclntsh18.ohso libasmperl18.ohso ORACLE_HOME={{ grid_home }}"
+  args:
+    chdir: "{{ grid_home }}/rdbms/lib"
+  environment:
+    ORACLE_HOME: "{{ grid_home }}"
+  when: oracle_ver == '18.0.0.0.0'
+  tags: rac-gi,rac-gi-install
+
 - name: rac-gi-install | Run script orainstRoot.sh
   become: true
   become_user: root

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -199,28 +199,17 @@
       - "{{ install_rac_gi.stdout_lines }}"
   tags: rac-gi,rac-gi-install
 
-- name: rac-gi-install | Fix up asmcmd in 12.2 (MOS note 2748316.1)
+- name: rac-gi-install | Fix up asmcmd in 12.2 and 18c (MOS note 2748316.1)
   become: yes
   become_user: "{{ grid_user }}"
-  register: fixup_asmcmd
-  shell: "make -f ins_rdbms.mk client_sharedlib libasmclntsh12.ohso libasmperl12.ohso ORACLE_HOME={{ grid_home }}"
+  command: "make -f ins_rdbms.mk client_sharedlib libasmclntsh{{ oracle_ver.split('.')[0] }}.ohso libasmperl{{ oracle_ver.split('.')[0] }}.ohso ORACLE_HOME={{ grid_home }}"
   args:
     chdir: "{{ grid_home }}/rdbms/lib"
   environment:
     ORACLE_HOME: "{{ grid_home }}"
-  when: oracle_ver == '12.2.0.1.0'
-  tags: rac-gi,rac-gi-install
-
-- name: rac-gi-install | Fix up asmcmd in 18c (MOS note 2748316.1)
-  become: yes
-  become_user: "{{ grid_user }}"
-  register: fixup_asmcmd
-  shell: "make -f ins_rdbms.mk client_sharedlib libasmclntsh18.ohso libasmperl18.ohso ORACLE_HOME={{ grid_home }}"
-  args:
-    chdir: "{{ grid_home }}/rdbms/lib"
-  environment:
-    ORACLE_HOME: "{{ grid_home }}"
-  when: oracle_ver == '18.0.0.0.0'
+  loop: "{{ lookup('inventory_hostnames', 'dbasm', wantlist=True) }}"
+  delegate_to: "{{ item }}"
+  when: oracle_ver_base in ['12.2', '18.0']
   tags: rac-gi,rac-gi-install
 
 - name: rac-gi-install | Run script orainstRoot.sh


### PR DESCRIPTION
In #112 we added a fix-up for asmcmd errors that blocked grid installed in 12cR2, based on MOS note 2748316.1.  Trying an 18c install, we get the same error:

```
11-Mar-25 16:45 ASMCMD Background (PID = 1318138):  Successfully opened the pipe /var/tmp/.oracle/asmcmd_fg_1318129
NOTE: Executing /u01/app/18.0.0/grid/bin/kfod op=getclstype..
11-Mar-25 16:45 cluster mode - ASM cluster : Flex mode enabled
11-Mar-25 16:45 (Process=1318138) BG unhandled exception before exiting kgfnGetConnDetails requires 4 parameters at /u01/app/18.0.0/grid/lib/asmcmdbase.pm line 6096.
```

A close reading of note 2748316.1 shows that, while the fix was for 12.2, the underlying issue was only resolved in 19.1.  So here we add an 18c version of the fix-up, using 18c versions of the object files.

Failed run before the change:  https://gist.github.com/mfielding/405b66ad6788231de43075cbeccf9af3
Successful run after the change (with a separate, unrelated issue with dbca):  https://gist.github.com/mfielding/a037717bc2fc2063411442b326837971