### PR TITLE
Remove redundant check in populate-swap-partition-id

### DIFF
--- a/roles/common/tasks/populate-swap-partition-id.yml
+++ b/roles/common/tasks/populate-swap-partition-id.yml
@@ -32,7 +32,7 @@
         part_path="${by_id_link}"-part1;
         ;;
     esac;
-    if [[ -e "$part_path" ]] && [[ "$part_path" != "" ]]; then
+    if [[ -e "$part_path" ]]; then
       echo "$part_path"
     else
       echo ""


### PR DESCRIPTION
## Change Description:
Review and optimize swap provisioning.

## Solution Overview:
The main playbook, `base-provision\tasks\swap.yml` works and looks well enough. It calls `populate-swap-partition-id.yml` which has a large block of shell commands - and this was the main area of the review. The logic of mapping device id to the `by-id` looks complex, however, I couldn't find a better alternative. There is one change to remove the check condition that is redundant.

## Test Commands:
Testing was done in OEL8 and OEL9.

```
time ./install-oracle.sh \
   --ora-swlib-bucket gs://[url]/19c \
   --ora-asm-disks-json '[ { "diskgroup": "DATA", "disks": [ { "blk_device": "/dev/sdd", "name": "DATA1" } ] }, { "diskgroup": "RECO", "disks": [ { "blk_device": "/dev/sde", "name": "RECO1" } ] } ]' \
   --ora-data-mounts-json '[ { "purpose": "software", "blk_device": "/dev/sdb", "name": "u01", "fstype": "xfs", "mount_point": "/u01", "mount_opts": "nofail" }, { "purpose": "diag", "blk_device": "/dev/sdc", "name": "u02", "fstype": "xfs", "mount_point": "/u02", "mount_opts": "nofail" } ]' \
   --swap-blk-device /dev/disk/by-id/google-oracle-swap \
   --instance-ip-addr ${INSTANCE_IP_ADDR} \
   --instance-hostname ${INSTANCE_HOSTNAME} \
   -- "--tags base-provision"
   
   
time ./install-oracle.sh \
   --ora-swlib-bucket gs://[url]/19c \
   --ora-asm-disks-json '[ { "diskgroup": "DATA", "disks": [ { "blk_device": "/dev/sdd", "name": "DATA1" } ] }, { "diskgroup": "RECO", "disks": [ { "blk_device": "/dev/sde", "name": "RECO1" } ] } ]' \
   --ora-data-mounts-json '[ { "purpose": "software", "blk_device": "/dev/sdb", "name": "u01", "fstype": "xfs", "mount_point": "/u01", "mount_opts": "nofail" }, { "purpose": "diag", "blk_device": "/dev/sdc", "name": "u02", "fstype": "xfs", "mount_point": "/u02", "mount_opts": "nofail" } ]' \
   --swap-blk-device /dev/sdb \
   --instance-ip-addr ${INSTANCE_IP_ADDR} \
   --instance-hostname ${INSTANCE_HOSTNAME} \
   -- "--tags base-provision"
```

### Test Prep:
Existing swap was disabled, swap partition was deleted, fstab entry removed, and VM rebooted.

### Test 1: details:
https://gist.github.com/pythianakhmadeev/c28cb9ef6ef149b0922273ed429b4130

### Test 2: details:
https://gist.github.com/pythianakhmadeev/12eeb87ef95b1c05b4ebb1efb5e93365

## Expected Results:
Swap partition is created on the specified block device