### PR TITLE
Some small terraform cleanups

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -58,6 +58,7 @@ Additionally, you will need:
 - A **Google Cloud project** with billing enabled
 - A **Service Account** with appropriate IAM roles for Compute Engine and Storage management
 - The following **IAM roles** added to the **Service Account** running **Terraform**:`roles/compute.instanceAdmin`, `roles/storage.objectAdmin`
+- A writeable [cloud storage bucket](https://cloud.google.com/storage/docs/creating-buckets) to store terraform state in
 
 ---
 
@@ -101,11 +102,11 @@ gcloud config set project PROJECT_ID
 
 2. Review and Edit Terraform Backend Configuration
 
-   Edit `terraform/backend.tf` to define your backend settings for your state file prefix and storage bucket.
+   Copy `terraform/backend.tf.example` to `terraform/backend.tf` and define your backend settings for your state file prefix and storage bucket.
 
 3. Review and Edit Terraform Module Configuration
 
-   Edit `terraform/main.tf` to define your deployment settings. Add however many ASM disks you require in the `asm_disks` and `fs_disks` sections.
+   Copy `terraform/main.tf.example` to `terraform/main.tf` and define your deployment settings. Add as many ASM disks you require in the `asm_disks` and `fs_disks` sections.
 
 > **NOTE** There is no need to supply the toolkit script parameters `--instance-ip-addr`, `--instance-ssh-user`, and `--instance-ssh-key` - these are automatically added by the Terraform commands.
 

--- a/terraform/backend.tf.example
+++ b/terraform/backend.tf.example
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = ">= 1.10.5"
 
   required_providers {
     google = {

--- a/terraform/main.tf.example
+++ b/terraform/main.tf.example
@@ -86,13 +86,13 @@ module "oracle_toolkit" {
   ora_version      = "ORA_VERSION" # example: "19"
   ora_backup_dest  = "BACKUP_DEST" # example: "+RECO"
   # Optional
-  ora_db_name       = "DB_NAME"     # example: "test"
+  ora_db_name       = ""            # example: "test"
   ora_db_container  = false         # example: false
-  ntp_pref          = "169.254.169.254" # example: "169.254.169.254"
-  oracle_release    = "latest"      # example: "19.7.0.0.200414"
-  ora_edition       = "EE"          # example: "EE"
-  ora_listener_port = "1521"        # example: 1521 
-  ora_redo_log_size = "100mb"       # example: "100MB"
+  ntp_pref          = ""            # example: "169.254.169.254"
+  oracle_release    = ""            # example: "19.7.0.0.200414"
+  ora_edition       = ""            # example: "EE"
+  ora_listener_port = ""            # example: 1521 
+  ora_redo_log_size = ""            # example: "100MB"
 
   ##############################################################################
   ## OPTIONAL SETTINGS

--- a/terraform/main.tf.example
+++ b/terraform/main.tf.example
@@ -29,12 +29,11 @@ module "oracle_toolkit" {
 
   # Instance settings
   instance_name        = "INSTANCE_NAME"  # example: oracle-rhel8-example
-  instance_count       = "INSTANCE_COUNT" # example: 1
   source_image_family  = "IMAGE_FAMILY"   # example: rhel-8
   source_image_project = "IMAGE_PROJECT"  # example: rhel-cloud
-  machine_type         = "MACHINE_TYPE"   # example: n2-standard-4
+  machine_type         = "MACHINE_TYPE"   # example: n4-standard-4
   os_disk_size         = "OS_DISK_SIZE"   # example: 100
-  os_disk_type         = "OS_DISK_TYPE"   # example: pd-balanced
+  os_disk_type         = "OS_DISK_TYPE"   # example: hyperdisk-balanced
 
   # Disk settings
   # By default, the list below will create 1 disk for filesystem, 2 disks for ASM and 1 disk for swap, the minimum required for a basic Oracle installation.
@@ -47,7 +46,7 @@ module "oracle_toolkit" {
       boot         = false
       device_name  = "oracle-u01"
       disk_size_gb = 50
-      disk_type    = "pd-balanced"
+      disk_type    = "hyperdisk-balanced"
       disk_labels  = { purpose = "software" } # Do not modify this label
     }
   ]
@@ -56,17 +55,17 @@ module "oracle_toolkit" {
     {
       auto_delete  = true
       boot         = false
-      device_name  = "oracle-asm-1"
+      device_name  = "oracle-data-1"
       disk_size_gb = 50
-      disk_type    = "pd-balanced"
+      disk_type    = "hyperdisk-balanced"
       disk_labels  = { diskgroup = "data", purpose = "asm" }
     },
     {
       auto_delete  = true
       boot         = false
-      device_name  = "oracle-asm-2"
+      device_name  = "oracle-reco-2"
       disk_size_gb = 50
-      disk_type    = "pd-balanced"
+      disk_type    = "hyperdisk-balanced"
       disk_labels  = { diskgroup = "reco", purpose = "asm" }
     },
     # Attributes other than disk_size_gb and disk_type should NOT be modified for the swap disk
@@ -75,7 +74,7 @@ module "oracle_toolkit" {
       boot         = false
       device_name  = "swap"
       disk_size_gb = 50
-      disk_type    = "pd-balanced"
+      disk_type    = "hyperdisk-balanced"
       disk_labels  = { purpose = "swap" }
     }
   ]
@@ -87,13 +86,13 @@ module "oracle_toolkit" {
   ora_version      = "ORA_VERSION" # example: "19"
   ora_backup_dest  = "BACKUP_DEST" # example: "+RECO"
   # Optional
-  ora_db_name       = "DB_NAME"            # example: "test"
-  ora_db_container  = "CONTAINER"          # example: false
-  ntp_pref          = "NTP_PREF"           # example: "169.254.169.254"
-  oracle_release    = "ORA_RELEASE"        # example: "19.7.0.0.200414"
-  ora_edition       = "ORA_EDITION"        # example: "EE"
-  ora_listener_port = "ORA_LISTERNER_PORT" # example: 1521 
-  ora_redo_log_size = "ORA_LOG_SIZE"       # example: "100MB"
+  ora_db_name       = "DB_NAME"     # example: "test"
+  ora_db_container  = false         # example: false
+  ntp_pref          = "169.254.169.254" # example: "169.254.169.254"
+  oracle_release    = "latest"      # example: "19.7.0.0.200414"
+  ora_edition       = "EE"          # example: "EE"
+  ora_listener_port = "1521"        # example: 1521 
+  ora_redo_log_size = "100mb"       # example: "100MB"
 
   ##############################################################################
   ## OPTIONAL SETTINGS

--- a/terraform/modules/oracle_toolkit_module/main.tf
+++ b/terraform/modules/oracle_toolkit_module/main.tf
@@ -126,7 +126,6 @@ module "compute_instance" {
   zone                = var.zone
   subnetwork          = var.subnetwork
   subnetwork_project  = local.project_id
-  num_instances       = var.instance_count
   hostname            = var.instance_name
   instance_template   = module.instance_template.self_link
   deletion_protection = false

--- a/terraform/modules/oracle_toolkit_module/variables.tf
+++ b/terraform/modules/oracle_toolkit_module/variables.tf
@@ -24,18 +24,13 @@ variable "fs_disks" {
   default     = []
 }
 
-variable "instance_count" {
-  description = "Number of instances to be created."
-  type        = number
-}
-
 variable "instance_name" {
-  description = "The name for the Instance."
+  description = "The name for the VM instance."
   type        = string
 }
 
 variable "machine_type" {
-  description = "The machine type to be used for the instance (e.g., n1-standard-2)."
+  description = "The machine type to be used for the instance (e.g., n4-standard-2)."
   type        = string
 }
 
@@ -143,10 +138,10 @@ variable "ora_version" {
 
 variable "oracle_release" {
   type        = string
-  default     = ""
+  default     = "latest"
   description = "Oracle release update version (patchlevel)."
   validation {
-    condition     = var.oracle_release == "" || can(regex("^\\d+(\\.\\d+)*$", var.oracle_release))
+    condition     = var.oracle_release == "" || var.oracle_release == "latest" || can(regex("^\\d+(\\.\\d+)*$", var.oracle_release))
     error_message = "Invalid Oracle release version. It should be in the format '19.10', '21.3.0.0', etc."
   }
 }
@@ -190,6 +185,7 @@ variable "source_image_project" {
 variable "subnetwork" {
   description = "The name of the GCP subnetwork to which the instance will be attached."
   type        = string
+  default     = "default"
 }
 
 variable "zone" {

--- a/terraform/modules/oracle_toolkit_module/versions.tf
+++ b/terraform/modules/oracle_toolkit_module/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = ">= 1.10.5"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
A few quick updates based on a first terraform run:

* Document the need to create a GCS bucket for terraform
* Rename `backend.tf` and `main.tf` to example files, so that users' edits won't be clobbered if they update the toolkit.  Update documentation to note.
* Loosen up terraform version requirements, to avoid everyone needing to update in lock step
* Removing references to `instance_count`:  we do not currently support either DR or clustered environments (or parameters for multiple DB names), so creating multiple VMs is pointless.
* Changing default machine and disk types to more modern n4 and hyberdisk-balanced generations
* Setting values for optional defaults in `main.tf.example`
* Permitting a default (and recommended) value of `latest` for the `ora_release`
* Using the `default` subnet by, you guessed it, default

Sample output (though I couldn't get through VM creation: https://gist.github.com/mfielding/bff9abbbfde2700d7946170d258db111;  we'll need to address external IPs and the associated security implications later).