### PR TITLE
Remove debugging comments from check-oracle.yml

### DIFF
--- a/check-oracle.yml
+++ b/check-oracle.yml
@@ -56,7 +56,6 @@
       when: (uninstall_ahf | bool) 
 
     - block:
-
         - name: Create AHF directory
           become: true
           file:
@@ -77,6 +76,16 @@
             local_ahf_path: "/tmp/{{ AHF_LOCATION | basename }}"
 
           block:
+            - name: Local AHF File
+              debug:
+                msg: "AHF File Source: {{ local_ahf_path }}"
+                verbosity: 1
+
+            - name: Remote AHF File Dest
+              debug:
+                msg: "AHF File Dest: {{ ahf_extract_path }}/{{ AHF_LOCATION | basename }}"
+                verbosity: 1
+
             - name: Download AHF file from Google Storage to the ansible control node.
               become: false
               local_action: 
@@ -298,6 +307,11 @@
           become: true
           shell:  cd  "{{ ORACHK_BASE }}/orachk/" && [[ -r orachk.orig ]] && rm -f orachk && mv orachk.orig orachk && rm -f orachk-quicktest.sh
           when: ( expedited_testing | bool )
+
+        - name: Debug the entire fetch_result
+          debug:
+            var: fetch_result
+            verbosity: 1
 
         # Only display the path if it exists in fetch_result.files
         - name: Display local path of fetched file

--- a/check-oracle.yml
+++ b/check-oracle.yml
@@ -56,6 +56,7 @@
       when: (uninstall_ahf | bool) 
 
     - block:
+
         - name: Create AHF directory
           become: true
           file:
@@ -76,22 +77,11 @@
             local_ahf_path: "/tmp/{{ AHF_LOCATION | basename }}"
 
           block:
-
-            # leave these here for testing
-            # this has been a problem area
-            #- name: Local AHF File
-              #debug:
-                #msg: "AHF File Source: {{ local_ahf_path }}"
-
-            #- name: Remote AHF File Dest
-              #debug:
-                #msg: "AHF File Dest: {{ ahf_extract_path }}/{{ AHF_LOCATION | basename }}"
-
             - name: Download AHF file from Google Storage to the ansible control node.
               become: false
               local_action: 
                 module: command
-                cmd: gcloud storage cp --verbosity=debug "{{ AHF_LOCATION }}" "{{ local_ahf_path }}"
+                cmd: gcloud storage cp "{{ AHF_LOCATION }}" "{{ local_ahf_path }}"
               register: gsutil_result
               changed_when: gsutil_result.rc == 0
 
@@ -308,12 +298,6 @@
           become: true
           shell:  cd  "{{ ORACHK_BASE }}/orachk/" && [[ -r orachk.orig ]] && rm -f orachk && mv orachk.orig orachk && rm -f orachk-quicktest.sh
           when: ( expedited_testing | bool )
-
-        # See what was actually returned by the fetch task
-        # this will be useful if the ansible version changes
-        # - name: Debug the entire fetch_result
-        # debug:
-        # var: fetch_result
 
         # Only display the path if it exists in fetch_result.files
         - name: Display local path of fetched file


### PR DESCRIPTION
Clean out some debugging that looks like was part of the development process.  We have a `--debug` option to expose variables (and much more) if necessary.

Sample output:  https://gist.github.com/mfielding/f9d518e28663c66b0f847636f9134578