### PR TITLE
Switch to ssh-keygen for PEM format and clarify task names

### DIFF
--- a/roles/ssh-setup/tasks/main.yml
+++ b/roles/ssh-setup/tasks/main.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-- name: Create .ssh dir if already present
+- name: Ensure /home/{{ ssh_user }}/.ssh directory exists with correct permissions
   become: true
   become_user: "{{ ssh_user }}"
   file:
@@ -24,45 +24,47 @@
     group: "{{ user_group }}"
   tags: ssh-keys
 
-- name: Generate ssh key on first node
+- name: Generate PKCS#1 RSA SSH key pair for user '{{ ssh_user }}' on first node
   become: true
   become_user: "{{ ssh_user }}"
-  openssh_keypair:
-    path: /home/{{ ssh_user }}/.ssh/id_rsa
-    mode: u=rw,go=
-    owner: "{{ ssh_user }}"
-    group: "{{ user_group }}"
-    private_key_format: "pkcs1"
-    backend: "cryptography"
-  register: ssh_key
+  command: ssh-keygen -m PEM -t rsa -b 2048  -f /home/{{ ssh_user }}/.ssh/id_rsa -N ''
+  args:
+    creates: /home/{{ ssh_user }}/.ssh/id_rsa
   tags: ssh-keys
 
-- name: Get key fingerprint
+- name: Read SSH public key for user '{{ ssh_user }}'
+  become: true
+  become_user: "{{ ssh_user }}"
+  command: cat /home/{{ ssh_user }}/.ssh/id_rsa.pub
+  register: user_ssh_pubkey
+  tags: ssh-keys
+
+- name: Collect SSH host key
   become: true
   become_user: "{{ ssh_user }}"
   command: ssh-keyscan -tecdsa {{ inventory_hostname }},{{ inventory_hostname }}.{{ ansible_domain }}
-  register: finger_key
+  register: host_ssh_pubkey
   tags: ssh-keys
 
-- name: Add key fingerprint to known_hosts file
+- name: Add SSH public host key for user '{{ ssh_user }}' to known_hosts file on all nodes
   become: true
   become_user: "{{ ssh_user }}"
   delegate_to: "{{ item }}"
   lineinfile:
     name: ~/.ssh/known_hosts
     create: true
-    line: "{{ finger_key.stdout }}"
+    line: "{{ host_ssh_pubkey.stdout }}"
     owner: "{{ ssh_user }}"
     group: "{{ user_group }}"
   loop: "{{ ssh_nodes }}"
   tags: ssh-keys
 
-- name: Key propagation to all nodes
+- name: Add SSH public key for user '{{ ssh_user }}' to authorized_keys on all nodes
   become: true
   become_user: root
   delegate_to: "{{ item }}"
   authorized_key:
-    key: "{{ ssh_key.public_key }}"
+    key: "{{ user_ssh_pubkey.stdout }}"
     user: "{{ ssh_user }}"
   loop: "{{ ssh_nodes }}"
   tags: ssh-keys

--- a/roles/ssh-setup/tasks/main.yml
+++ b/roles/ssh-setup/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Generate PKCS#1 RSA SSH key pair for user '{{ ssh_user }}' on first node
   become: true
   become_user: "{{ ssh_user }}"
-  command: ssh-keygen -m PEM -t rsa -b 2048  -f /home/{{ ssh_user }}/.ssh/id_rsa -N ''
+  command: ssh-keygen -m PEM -t rsa -b 2048  -f "/home/{{ ssh_user }}/.ssh/id_rsa" -N ''
   args:
     creates: /home/{{ ssh_user }}/.ssh/id_rsa
   tags: ssh-keys
@@ -35,7 +35,7 @@
 - name: Read SSH public key for user '{{ ssh_user }}'
   become: true
   become_user: "{{ ssh_user }}"
-  command: cat /home/{{ ssh_user }}/.ssh/id_rsa.pub
+  command: cat "/home/{{ ssh_user }}/.ssh/id_rsa.pub"
   register: user_ssh_pubkey
   tags: ssh-keys
 


### PR DESCRIPTION
Replace the use of Ansible's openssh_keypair module with a direct call to ssh-keygen in order to fix the following [error](https://oss.gprow.dev/view/gs/gcp-oracle-prow-bucket/pr-logs/pull/google_oracle-toolkit/233/oracle-toolkit-install/1914377806712672256):


```
Unsupported parameters for (openssh_keypair) module: backend, private_key_format
Supported parameters include: attributes, backup, comment, content, delimiter, directory_mode, follow, force, group, mode, owner, path, regexp, remote_src, selevel, serole, setype, seuser, size, src, state, type, unsafe_writes
```

The private_key_format and backend parameters are only available in the community.crypto collection (v1.7.0+), which would require users to install an external dependency. Using ssh-keygen directly avoids the need for additional collections.

Also updated task names and variable names to improve clarity.


Testing:
Manually ran presubmit tests on BMS machines. [The modified tasks completed successfully](https://gist.github.com/AlexBasinov/321604e901359fa72a493e48eaa032bd). However, the "rac-gi-install" task failed with the following error:

```
The cluster name (oracle-toolkit-) cannot end with hyphen character (-).
ACTION: Specify a valid cluster name.
```


This appears to be a completely different issue unrelated to the changes in this PR.