### PR TITLE
Improve parameter error handling for Data Guard invocations

### DIFF
--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -191,7 +191,7 @@ GCS_BACKUP_BUCKET="${GCS_BACKUP_BUCKET}"
 GCS_BACKUP_BUCKET_PARAM="^.+[^/]"
 
 GCS_BACKUP_TEMP_PATH="${GCS_BACKUP_TEMP_PATH:-/u01/gcsfusetmp}"
-GCS_BACKUP_TEMP_PATH_PARAM="^/.*" 
+GCS_BACKUP_TEMP_PATH_PARAM="^/.*"
 
 ARCHIVE_REDUNDANCY="${ARCHIVE_REDUNDANCY:-2}"
 ARCHIVE_REDUNDANCY_PARAM="^[0-9]+$"
@@ -571,7 +571,7 @@ shopt -s nocasematch
   echo "Incorrect parameter provided for ora-edition: $ORA_EDITION"
   exit 1
 }
-[[ ! "$ORA_EDITION" =~ "EE" ]] && [[ "$CLUSTER_TYPE" =~ "DG" ]] && {
+[[ ! "$ORA_EDITION" == "EE" ]] && [[ "$CLUSTER_TYPE" == "DG" ]] && {
   echo "ora-edition should be EE with cluster-type DG"
   exit 1
 }
@@ -637,16 +637,16 @@ shopt -s nocasematch
   exit 1
 }
 [[ -n "$ORA_ASM_DISKS_JSON" && ! "$ORA_ASM_DISKS_JSON" =~ $ORA_ASM_DISKS_JSON_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-asm-disks-json: $ORA_ASM_DISKS_JSON"
-    exit 1
+  echo "Incorrect parameter provided for ora-asm-disks-json: $ORA_ASM_DISKS_JSON"
+  exit 1
 }
 [[ ! "$ORA_DATA_MOUNTS" =~ $ORA_DATA_MOUNTS_PARAM ]] && {
   echo "Incorrect parameter provided for ora-data-mounts: $ORA_DATA_MOUNTS"
   exit 1
 }
 [[ -n "$ORA_DATA_MOUNTS_JSON" && ! "$ORA_DATA_MOUNTS_JSON" =~ $ORA_DATA_MOUNTS_JSON_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-data-mounts-json: $ORA_DATA_MOUNTS_JSON"
-    exit 1
+  echo "Incorrect parameter provided for ora-data-mounts-json: $ORA_DATA_MOUNTS_JSON"
+  exit 1
 }
 [[ ! "$CLUSTER_CONFIG" =~ $CLUSTER_CONFIG_PARAM ]] && {
   echo "Incorrect parameter provided for cluster-config: $CLUSTER_CONFIG"
@@ -744,8 +744,16 @@ shopt -s nocasematch
   echo "Incorrect parameter provided for instance-ip-addr: $INSTANCE_IP_ADDR"
   exit 1
 }
-[[ ! "$PRIMARY_IP_ADDR" =~ ${PRIMARY_IP_ADDR_PARAM} ]] && [[ "$CLUSTER_TYPE" =~ "DG" ]] && {
+[[ "$INSTANCE_IP_ADDR" == "$PRIMARY_IP_ADDR" ]] && {
+  echo "ERROR: Both instance-ip-addr and primary-ip-addr are set to: $INSTANCE_IP_ADDR"
+  exit 1
+}
+[[ ! "$PRIMARY_IP_ADDR" =~ ${PRIMARY_IP_ADDR_PARAM} ]] && [[ "$CLUSTER_TYPE" == "DG" ]] && {
   echo "Incorrect parameter provided for primary-ip-addr: $PRIMARY_IP_ADDR"
+  exit 1
+}
+[[ -n "$PRIMARY_IP_ADDR" ]] && [[ "$CLUSTER_TYPE" != "DG" ]] && {
+  echo "Parameter cluster-type: $CLUSTER_TYPE, but primary-ip-addr should only be used with cluster-type: DG"
   exit 1
 }
 [[ ! "$INSTANCE_SSH_USER" =~ $INSTANCE_SSH_USER_PARAM ]] && {

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -744,7 +744,7 @@ shopt -s nocasematch
   echo "Incorrect parameter provided for instance-ip-addr: $INSTANCE_IP_ADDR"
   exit 1
 }
-[[ "$INSTANCE_IP_ADDR" == "$PRIMARY_IP_ADDR" ]] && {
+[[ "$INSTANCE_IP_ADDR" == "$PRIMARY_IP_ADDR" ]] && [[ "$CLUSTER_TYPE" != "RAC" ]] && {
   echo "ERROR: Both instance-ip-addr and primary-ip-addr are set to: $INSTANCE_IP_ADDR"
   exit 1
 }

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -571,7 +571,7 @@ shopt -s nocasematch
   echo "Incorrect parameter provided for ora-edition: $ORA_EDITION"
   exit 1
 }
-[[ ! "$ORA_EDITION" == "EE" ]] && [[ "$CLUSTER_TYPE" == "DG" ]] && {
+[[ "$ORA_EDITION" != "EE" ]] && [[ "$CLUSTER_TYPE" == "DG" ]] && {
   echo "ora-edition should be EE with cluster-type DG"
   exit 1
 }


### PR DESCRIPTION
## Change Description:

Certain failure, or problem conditions are encountered when the parameters related to Data Guard implementations are not used properly. Specifically:

#### Scenario 1. If the `INSTANCE_IP_ADDR` and `PRIMARY_IP_ADDR` environment variables are set but the `--cluster-type DG` option is not used:

- This scenario can happen if the user accidentally has `PRIMARY_IP_ADDR` set, perhaps from a prior usage of the tool from within the same shell session, but is now trying to do a non-DG installation.
- Result is that the script will run and will try to perform the Data Guard Ansible tasks (such as the `db-copy` role) regardless and will subsequently, and after some period of time and a number of managed host changes, fail.

Solution is to ensure that when both the `INSTANCE_IP_ADDR` and `PRIMARY_IP_ADDR` environment variables are set, that the `--cluster-type DG` option is also used.

#### Scenario 2. The `--cluster-type DG` option is used but both `INSTANCE_IP_ADDR` and `PRIMARY_IP_ADDR` are set to the same value.

- This situation can happen when the user accidentally uses the same IP address for both the Data Guard primary and standby servers.
- The result is that the toolkit will execute and try to setup a DG standby on the same server as the primary

Solution is to simply verify that `$INSTANCE_IP_ADDR != $PRIMARY_IP_ADDR` when the `--cluster-type DG` option is used.

#### Additional Changes

Additionally, this change includes some minor bash test changes, changing from a regular expression comparison `=~` to a proper equality comparison operator `==` when testing against the litteral strings `DG` or `EE`.

## Changed Behavior After Change:

Example output when `PRIMARY_IP_ADDR` is defined but the `CLUSTER_TYPE` is not set and is defaulting to `NONE`:

```
$ export PRIMARY_IP_ADDR=10.2.80.42
$
$ ./install-oracle.sh \
>   --instance-ip-addr ${INSTANCE_IP_ADDR} \
>   --instance-hostname standby-server19c \
>   --ora-version 19 \
>   --ora-swlib-bucket gs://BUCKET_NAME/19c \
>   --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
>   --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]' \
>   --backup-dest "+RECO" \
>   --no-patch \
>   --primary-ip-addr ${PRIMARY_IP_ADDR}
Command used:
./install-oracle.sh --instance-ip-addr 10.2.80.57 --instance-hostname standby-server19c --ora-version 19 --ora-swlib-bucket gs://BUCKET_NAME/19c --ora-data-mounts-json [{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}] --ora-asm-disks-json [{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}] --backup-dest +RECO --no-patch --primary-ip-addr 10.2.80.42

Parameter cluster-type: NONE, but primary-ip-addr should only be used with cluster-type: DG

```

Example when both `INSTANCE_IP_ADDR` and `PRIMARY_IP_ADDR` are accidentally set to the same value:

```
$ export INSTANCE_IP_ADDR=10.2.80.57
$ export PRIMARY_IP_ADDR=$INSTANCE_IP_ADDR
$
$ ./install-oracle.sh \
>   --instance-ip-addr ${INSTANCE_IP_ADDR} \
>   --instance-hostname standby-server19c \
>   --ora-version 19 \
>   --ora-swlib-bucket gs://BUCKET_NAME/19c \
>   --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
>   --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]' \
>   --backup-dest "+RECO" \
>   --no-patch \
>   --primary-ip-addr ${PRIMARY_IP_ADDR} \
>   --cluster-type DG
Command used:
./install-oracle.sh --instance-ip-addr 10.2.80.57 --instance-hostname standby-server19c --ora-version 19 --ora-swlib-bucket gs://BUCKET_NAME/19c --ora-data-mounts-json [{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}] --ora-asm-disks-json [{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}] --backup-dest +RECO --no-patch --primary-ip-addr 10.2.80.57 --cluster-type DG

ERROR: Both instance-ip-addr and primary-ip-addr are set to: 10.2.80.57

```

## Validation of Normal Functionality:

When both `INSTANCE_IP_ADDR` and `PRIMARY_IP_ADDR` are set to different values, and the `--cluster-type DG` option is used, the toolkit runs:

```
$ export INSTANCE_IP_ADDR=10.2.80.57
$ export PRIMARY_IP_ADDR=10.2.80.42
$
$ ./install-oracle.sh \
>   --instance-ip-addr ${INSTANCE_IP_ADDR} \
>   --instance-hostname standby-server19c \
>   --ora-version 19 \
>   --ora-swlib-bucket gs://BUCKET_NAME/19c \
>   --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
>   --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]' \
>   --backup-dest "+RECO" \
>   --no-patch \
>   --primary-ip-addr ${PRIMARY_IP_ADDR} \
>   --cluster-type DG
Command used:
./install-oracle.sh --instance-ip-addr 10.2.80.57 --instance-hostname standby-server19c --ora-version 19 --ora-swlib-bucket gs://BUCKET_NAME/19c --ora-data-mounts-json [{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}] --ora-asm-disks-json [{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}] --backup-dest +RECO --no-patch --primary-ip-addr 10.2.80.42 --cluster-type DG

WARNING: ignoring --ora-data-mounts because --ora-data-mounts-json is specified
WARNING: ignoring --ora-asm-disks because --ora-asm-disks-json is specified

Inventory file for this execution: ./inventory_files/inventory_standby-server19c_ORCL.

Running with parameters from command line or environment variables:

ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
ANSIBLE_LOG_PATH=./logs/log_ORCL_20250423_111758_DG.log
ARCHIVE_BACKUP_MIN=30
ARCHIVE_ONLINE_DAYS=7
ARCHIVE_REDUNDANCY=2
BACKUP_DEST=+RECO
BACKUP_LEVEL0_DAYS=0
BACKUP_LEVEL1_DAYS=1-6
BACKUP_LOG_LOCATION=/home/oracle/logs
BACKUP_REDUNDANCY=2
BACKUP_SCRIPT_LOCATION=/home/oracle/scripts
BACKUP_START_HOUR=01
BACKUP_START_MIN=00
CLUSTER_CONFIG=cluster_config.json
CLUSTER_CONFIG_JSON=
CLUSTER_TYPE=DG
GCS_BACKUP_BUCKET=
GCS_BACKUP_CONFIG=
GCS_BACKUP_TEMP_PATH=/u01/gcsfusetmp
INSTANCE_HOSTGROUP_NAME=dbasm
INSTANCE_HOSTNAME=standby-server19c
INSTANCE_IP_ADDR=10.2.80.57
INSTANCE_SSH_EXTRA_ARGS=''\''-o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityAgent=no'\'''
INSTANCE_SSH_KEY='~/.ssh/id_rsa'
INSTANCE_SSH_USER=pane
ORA_ASM_DISKS=asm_disk_config.json
ORA_ASM_DISKS_JSON='[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]'
ORA_DATA_DESTINATION=DATA
ORA_DATA_MOUNTS=data_mounts_config.json
ORA_DATA_MOUNTS_JSON='[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]'
ORA_DB_CHARSET=AL32UTF8
ORA_DB_CONTAINER=TRUE
ORA_DB_DOMAIN=
ORA_DB_NAME=ORCL
ORA_DB_NCHARSET=AL16UTF16
ORA_DB_TYPE=MULTIPURPOSE
ORA_DISK_MGMT=UDEV
ORA_EDITION=EE
ORA_LISTENER_NAME=LISTENER
ORA_LISTENER_PORT=1521
ORA_PDB_COUNT=1
ORA_PDB_NAME_PREFIX=PDB
ORA_RECO_DESTINATION=RECO
ORA_REDO_LOG_SIZE=100MB
ORA_RELEASE=base
ORA_ROLE_SEPARATION=TRUE
ORA_STAGING=/u01/swlib
ORA_SWLIB_BUCKET=gs://BUCKET_NAME/19c
ORA_SWLIB_CREDENTIALS=
ORA_SWLIB_PATH=/u01/swlib
ORA_SWLIB_TYPE=GCS
ORA_VERSION=19.3.0.0.0
PB_CHECK_INSTANCE=check-instance.yml
PB_CONFIG_DB=config-db.yml
PB_CONFIG_RAC_DB=config-rac-db.yml
PB_INSTALL_SW=install-sw.yml
PB_LIST='check-instance.yml prep-host.yml install-sw.yml config-db.yml'
PB_PREP_HOST=prep-host.yml
PRIMARY_IP_ADDR=10.2.80.42

Ansible params:  -e '{"asm_disk_input":[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]}' -e '{"data_mounts_input":[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]}'
Found Ansible: ansible-playbook is /usr/bin/ansible-playbook

Running Ansible playbook: ansible-playbook -i ./inventory_files/inventory_standby-server19c_ORCL   -e '{"asm_disk_input":[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]}' -e '{"data_mounts_input":[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]}' check-instance.yml

PLAY [dbasm] ***********************************************************************************************************************************************************************

TASK [Verify that Ansible on control node meets the version requirements] **********************************************************************************************************
ok: [standby-server19c] => {
    "changed": false,
    "msg": "Ansible version is 2.16.3, continuing"
}

...

```