### PR TITLE
Optimizations (fixes and enhancements) to RMAN active duplicate tasks

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -105,10 +105,9 @@ prereq_option: "{% if oracle_ver_base in ('11.2', '12.1') %}-ignorePrereq{% else
 # section for DR
 
 # db_unique_name identifies uniqueness of a database in Data Guard configuration.
-# By default in the script it set to "_s" so it might be helpful to overwrite the variable
-# and set it to the suffix which identifies location of the standby database
-# (like "_sydney" for example)
-# The same suffix will be "attached" to the db name in DG configuration as well.
+# For the standby database, this is represented by the Ansible "standby_name"
+# variable. This variable can be customized as desired.  For example, using the
+# suffix "_s" or something location specific (i.e. "_sydney").
 standby_suffix: _s
 standby_name: "{{ db_name }}{{ standby_suffix }}"
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -110,6 +110,7 @@ prereq_option: "{% if oracle_ver_base in ('11.2', '12.1') %}-ignorePrereq{% else
 # (like "_sydney" for example)
 # The same suffix will be "attached" to the db name in DG configuration as well.
 standby_suffix: _s
+standby_name: "{{ db_name }}{{ standby_suffix }}"
 
 # section size to use during RMAN duplicate
 section_size: 32G

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -38,7 +38,7 @@
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
 
-    - name: Active-copy | Set random password
+    - name: Active-copy | Generate random password
       set_fact:
         sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
 
@@ -82,7 +82,7 @@
       set_fact:
         password_file_name: "{{ password_file if password_file | length > 0 else (oracle_home + '/dbs/orapw' + db_name) if orapw_home_stat.stat.exists else (oracle_base + '/dbs/orapw' + db_name) }}"
 
-    - name: Active-copy | Backup password file from file system
+    - name: Active-copy | Back up password file from file system
       copy:
         src: "{{ password_file_name }}"
         dest: "{{ oracle_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M') }}"
@@ -97,7 +97,7 @@
         - password_file is not search('^\\+')
         - (orapw_home_stat.stat.exists or orapw_base_stat.stat.exists)
 
-    - name: Active-copy | Backup password file from ASM
+    - name: Active-copy | Back up password file from ASM
       shell: |
         set -o pipefail
         asmcmd cp {{ password_file }} {{ grid_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M') }}
@@ -146,7 +146,7 @@
       become_user: "{{ grid_user }}"
       when: standby_listener_update.changed
 
-    - name: Active-copy | Create directories
+    - name: Active-copy | Create audit dump directory
       file:
         path: "{{ oracle_base }}/admin/{{ oracle_sid }}/adump"
         state: directory
@@ -192,7 +192,7 @@
       become_user: "{{ oracle_user }}"
       no_log: true
 
-    - name: Active-copy | Get duplicate script
+    - name: Active-copy | Generate duplicate script
       template:
         src: duplicate.cmd.j2
         dest: "{{ oracle_home }}/dbs/duplicate.cmd"

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -13,212 +13,272 @@
 # limitations under the License.
 
 ---
-- name: Active-copy | Check pmon process
+- name: Active-copy | Check if standby database is already running
   shell: |
-    set -o pipefail
-    ps -ef | ( grep pmon || true ) | ( grep -i {{ oracle_sid }}$ || true ) | ( grep -v grep || true ) | wc -l
+    srvctl status database -d {{ standby_name }} || true
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: true
+  become_user: "{{ oracle_user }}"
   changed_when: false
-  register: pmon_proc
+  register: standby_status
   tags: active-duplicate
 
-- name: Active-copy | Add oratab entry
-  lineinfile:
-    path: /etc/oratab
-    regexp: '^{{ oracle_sid }}\:'
-    line: "{{ oracle_sid }}:{{ oracle_home }}:N"
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
-  become: true
+- name: Active-copy | Run RMAN duplicate tasks
+  when: "'is running' not in standby_status.stdout"
   tags: active-duplicate
+  block:
+    - name: Active-copy | Add oratab entry
+      lineinfile:
+        path: /etc/oratab
+        regexp: '^{{ oracle_sid }}\:'
+        line: "{{ oracle_sid }}:{{ oracle_home }}:N"
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
 
-- name: Active-copy | Set random password
-  set_fact:
-    sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
-  tags: active-duplicate
+    - name: Active-copy | Set random password
+      set_fact:
+        sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
 
-- name: Active-copy | Get primary db password file information
+    - name: Active-copy | Get primary db password file information
+      shell: |
+        set -o pipefail
+        srvctl config db -d {{ db_name }} | grep "^Password file"
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+      changed_when: false
+      register: srvctl_output
+
+    - name: Active-copy | Password file variable
+      set_fact:
+        password_file: "{{ srvctl_output.stdout | regex_replace('^Password file:') | regex_replace('\\s') }}"
+
+    - name: Active-copy | Search for password file in ORACLE_HOME
+      stat:
+        path: "{{ oracle_home }}/dbs/orapw{{ db_name }}"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+      register: orapw_home_stat
+      when: password_file | length == 0
+
+    - name: Active-copy | Search for password file in ORACLE_BASE
+      stat:
+        path: "{{ oracle_base }}/dbs/orapw{{ db_name }}"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+      register: orapw_base_stat
+      when: password_file | length == 0 and not orapw_home_stat.stat.exists
+
+    - name: Active-copy | Set password file name variable
+      set_fact:
+        password_file_name: "{{ password_file if password_file | length > 0 else (oracle_home + '/dbs/orapw' + db_name) if orapw_home_stat.stat.exists else (oracle_base + '/dbs/orapw' + db_name) }}"
+
+    - name: Active-copy | Backup password file from file system
+      copy:
+        src: "{{ password_file_name }}"
+        dest: "{{ oracle_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M') }}"
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wr,go="
+        remote_src: true
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+      when:
+        - password_file is not search('^\\+')
+        - (orapw_home_stat.stat.exists or orapw_base_stat.stat.exists)
+
+    - name: Active-copy | Backup password file from ASM
+      shell: |
+        set -o pipefail
+        asmcmd cp {{ password_file }} {{ grid_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M') }}
+      environment:
+        ORACLE_HOME: "{{ grid_home }}"
+        ORACLE_SID: "{{ asm_sid }}"
+        PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ grid_user }}"
+      when: password_file is search('^\\+')
+
+    - name: Active-copy | Set sys password for primary db
+      command:
+        argv:
+          - "{{ oracle_home }}/bin/orapwd"
+          - "file={{ password_file_name }}"
+          - "force=y"
+          - "password={{ sys_pass }}"
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+      no_log: true
+
+    - name: Active-copy | Add static listener entry
+      lineinfile:
+        path: "{{ grid_home }}/network/admin/listener.ora"
+        regexp: "^SID_LIST_{{ listener_name }}"
+        line: "SID_LIST_{{ listener_name }}=(SID_LIST=(SID_DESC=(GLOBAL_DBNAME={{ standby_name }}{% if db_domain | default('', true) | length > 0 %}.{{ db_domain }}{% endif %})(ORACLE_HOME={{ oracle_home }})(SID_NAME={{ oracle_sid }})))"
+        owner: "{{ grid_user }}"
+        group: "{{ oracle_group }}"
+      register: standby_listener_update
+      become: true
+      become_user: "{{ grid_user }}"
+
+    - name: Active-copy | Reload listener
+      shell: "{{ grid_home }}/bin/lsnrctl reload {{ listener_name }}"
+      environment:
+        ORACLE_HOME: "{{ grid_home }}"
+        PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ grid_user }}"
+      when: standby_listener_update.changed
+
+    - name: Active-copy | Create directories
+      file:
+        path: "{{ oracle_base }}/admin/{{ oracle_sid }}/adump"
+        state: directory
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wrx,go="
+
+    - name: Active-copy | Create auxiliary init file
+      template:
+        src: initaux.ora.j2
+        dest: "{{ oracle_home }}/dbs/init{{ oracle_sid }}.ora"
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wr,go="
+
+    - name: Active-copy | Start auxiliary instance
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        startup nomount pfile={{ oracle_home }}/dbs/init{{ oracle_sid }}.ora force
+        alter system register;
+        host sleep 60
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: Active-copy | Set sys password for auxiliary instance
+      command:
+        argv:
+          - "{{ oracle_home }}/bin/orapwd"
+          - "file={{ password_file_name }}"
+          - "force=y"
+          - "password={{ sys_pass }}"
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+      no_log: true
+
+    - name: Active-copy | Get duplicate script
+      template:
+        src: duplicate.cmd.j2
+        dest: "{{ oracle_home }}/dbs/duplicate.cmd"
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wr,go="
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: Active-copy | Duplicate primary database
+      command:
+        argv:
+          - "{{ oracle_home }}/bin/rman"
+          - 'target "sys/{{ sys_pass }}@//{{ lookup(''env'', ''PRIMARY_IP_ADDR'') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{% if db_domain | default('''', true) | length > 0 %}.{{ db_domain }}{% endif %}"'
+          - 'auxiliary "sys/{{ sys_pass }}@//{{ lookup(''env'', ''INSTANCE_IP_ADDR'') }}:{{ listener_port | default(1521, true) }}/{{ standby_name }}{% if db_domain | default('''', true) | length > 0 %}.{{ db_domain }}{% endif %}"'
+          - "cmdfile={{ oracle_home }}/dbs/duplicate.cmd"
+          - "log={{ oracle_home }}/dbs/duplicate.log"
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: Active-copy | Add Oracle Restart configuration
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        shutdown immediate
+        EOF
+        srvctl add db \
+          -d {{ standby_name }} \
+          -dbname {{ db_name }} \
+          -instance {{ oracle_sid }} \
+          -oraclehome {{ oracle_home }} {% if db_domain | default('', true) | length > 0 %}-domain {{ db_domain }}{% endif %} \
+          -spfile {{ oracle_home }}/dbs/spfile{{ db_name }}.ora \
+          -pwfile {{ password_file_name }} \
+          -role PHYSICAL_STANDBY \
+          -startoption MOUNT \
+          -stopoption IMMEDIATE
+        srvctl start db -d {{ standby_name }}
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: Active-copy | Run tasks from the database adjustments role
+      include_role:
+        name: db-adjustments
+
+    - name: Active-copy | Move spfile into ASM and restart
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        create pfile='/tmp/init@.backup' from spfile;
+        create spfile='+{{ data_destination }}/{{ standby_name }}/PARAMETERFILE/spfile.ora' from pfile='/tmp/init@.backup';
+        EOF
+        srvctl modify db -d {{ standby_name }} -spfile '+{{ data_destination }}/{{ standby_name }}/PARAMETERFILE/spfile.ora'
+        srvctl stop db -d {{ standby_name }} -stopoption immediate
+        srvctl start db -d {{ standby_name }}
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+
+- name: Active-copy | Capture standby database state
   shell: |
     set -o pipefail
-    srvctl config db -d {{ db_name }} | grep "^Password file"
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  delegate_to: primary1
-  become: true
-  become_user: "{{ oracle_user }}"
-  register: srvctl_output
-  tags: active-duplicate
-
-- name: Active-copy | Password file variable
-  set_fact:
-    password_file: "{{ srvctl_output.stdout | regex_replace('^Password file:') | regex_replace('\\s') }}"
-  tags: active-duplicate
-
-- name: Active-copy | Backup password file from file system
-  copy:
-    src: "{% if password_file | length > 0 %}{{ password_file }}{% else %}{{ oracle_home }}/dbs/orapw{{ db_name }}{% endif %}"
-    dest: "{{ oracle_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M') }}"
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
-    mode: "u=wr,go="
-    remote_src: true
-  delegate_to: primary1
-  become: true
-  become_user: "{{ oracle_user }}"
-  when: password_file is not search('^\\+')
-  tags: active-duplicate
-
-- name: Active-copy | Backup password file from ASM
-  shell: |
-    set -o pipefail
-    asmcmd cp {{ password_file }} {{ grid_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M') }}
-  environment:
-    ORACLE_HOME: "{{ grid_home }}"
-    ORACLE_SID: "{{ asm_sid }}"
-    PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  delegate_to: primary1
-  become: true
-  become_user: "{{ grid_user }}"
-  when: password_file is search('^\\+')
-  tags: active-duplicate
-
-- name: Active-copy | Set sys password for primary db
-  command:
-    argv:
-      - "{{ oracle_home }}/bin/orapwd"
-      - "file={{ oracle_home }}/dbs/orapw{{ db_name }}"
-      - "force=y"
-      - "password={{ sys_pass }}"
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  delegate_to: primary1
-  become: true
-  become_user: "{{ oracle_user }}"
-  no_log: true
-  tags: active-duplicate
-
-- name: Active-copy | Add static listener entry
-  lineinfile:
-    path: "{{ grid_home }}/network/admin/listener.ora"
-    regexp: "^SID_LIST_{{ listener_name }}"
-    line: "SID_LIST_{{ listener_name }}=(SID_LIST=(SID_DESC=(GLOBAL_DBNAME={{ oracle_sid }}{{ standby_suffix }}{% if db_domain | default('', true) | length > 0 %}.{{ db_domain }}{% endif %})(ORACLE_HOME={{ oracle_home }})(SID_NAME={{ oracle_sid }})))"
-    owner: "{{ grid_user }}"
-    group: "{{ oracle_group }}"
-  become: true
-  tags: active-duplicate
-
-- name: Active-copy | Reload listener
-  shell: "{{ grid_home }}/bin/lsnrctl reload {{ listener_name }}"
-  environment:
-    ORACLE_HOME: "{{ grid_home }}"
-    PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ grid_user }}"
-  tags: active-duplicate
-
-- name: Active-copy | Create directories
-  file:
-    path: "{{ oracle_base }}/admin/{{ oracle_sid }}/adump"
-    state: directory
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
-    mode: "u=wrx,go="
-  become: true
-  tags: active-duplicate
-
-- name: Active-copy | Create auxiliary init file
-  template:
-    src: initaux.ora.j2
-    dest: "{{ oracle_home }}/dbs/init{{ oracle_sid }}.ora"
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
-    mode: "u=wr,go="
-  become: true
-  tags: active-duplicate
-
-- name: Active-copy | Start auxiliary instance
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
-    startup nomount pfile={{ oracle_home }}/dbs/init{{ oracle_sid }}.ora force
-    alter system register;
-    host sleep 60
-    EOF
+    srvctl config db -d {{ standby_name }}
+    srvctl status db -d {{ standby_name }}
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
   become: true
   become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: standby_state
   tags: active-duplicate
 
-- name: Active-copy | Set sys password for auxiliary instance
-  command:
-    argv:
-      - "{{ oracle_home }}/bin/orapwd"
-      - "file={{ oracle_home }}/dbs/orapw{{ db_name }}"
-      - "force=y"
-      - "password={{ sys_pass }}"
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
-  no_log: true
-  tags: active-duplicate
-
-- name: Active-copy | Get duplicate script
-  template:
-    src: duplicate.cmd.j2
-    dest: "{{ oracle_home }}/dbs/duplicate.cmd"
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
-    mode: "u=wr,go="
-  become: true
-  become_user: "{{ oracle_user }}"
-  tags: active-duplicate
-
-- name: Active-copy | Duplicate primary database
-  command:
-    argv:
-      - "{{ oracle_home }}/bin/rman"
-      - "target \"sys/{{ sys_pass }}@//{{ lookup('env', 'PRIMARY_IP_ADDR') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{% if db_domain | default('', true) | length > 0 %}.{{ db_domain }}{% endif %}\""
-      - "auxiliary \"sys/{{ sys_pass }}@//{{ lookup('env', 'INSTANCE_IP_ADDR') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{% if db_domain | default('', true) | length > 0 %}.{{ db_domain }}{% endif %}\""
-      - "cmdfile={{ oracle_home }}/dbs/duplicate.cmd"
-      - "log={{ oracle_home }}/dbs/duplicate.log"
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
-  no_log: true
-  tags: active-duplicate
-
-- name: Active-copy | Add Oracle Restart configuration
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
-    shutdown immediate
-    EOF
-    srvctl add db -d {{ db_name }}{{ standby_suffix }} \
-      -oraclehome {{ oracle_home }} {% if db_domain | default('', true) | length > 0 %}-domain {{ db_domain }}{% endif %} \
-      -spfile {{ oracle_home }}/dbs/spfile{{ db_name }}.ora \
-      -pwfile {{ oracle_home }}/dbs/orapw{{ db_name }} \
-      -role PHYSICAL_STANDBY \
-      -startoption MOUNT \
-      -stopoption IMMEDIATE \
-      -instance {{ oracle_sid }} \
-      -dbname {{ db_name }}
-    srvctl start db -d {{ db_name }}{{ standby_suffix }}
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
+- name: Active-copy | Show standby database state
+  debug:
+    var: standby_state.stdout_lines
+    verbosity: 0
   tags: active-duplicate

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -52,12 +52,17 @@
     - name: Active-copy | Reload listener
       shell: |
         {{ grid_home }}/bin/lsnrctl reload {{ listener_name }}
-        sleep 60
       environment:
         ORACLE_HOME: "{{ grid_home }}"
         PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
       become: true
       become_user: "{{ grid_user }}"
+      when: standby_listener_update.changed
+
+    - name: Active-copy | Pause for one minute to ensure that the listener has fully restarted and the LsnrAgt process has registered
+      wait_for:
+        timeout: 60
+      delegate_to: localhost
       when: standby_listener_update.changed
 
     - name: Active-copy | Create audit dump directory

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-- name: Active-copy | Check if standby database is already running
+- name: Active-copy | Check if the standby database is already running
   shell: |
     srvctl status database -d {{ standby_name }} || true
   environment:
@@ -38,11 +38,57 @@
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
 
-    - name: Active-copy | Generate random password
-      set_fact:
-        sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
+    - name: Active-copy | Add static listener entry
+      lineinfile:
+        path: "{{ grid_home }}/network/admin/listener.ora"
+        regexp: "^SID_LIST_{{ listener_name }}"
+        line: "SID_LIST_{{ listener_name }}=(SID_LIST=(SID_DESC=(GLOBAL_DBNAME={{ standby_name }}{% if db_domain | default('', true) | length > 0 %}.{{ db_domain }}{% endif %})(ORACLE_HOME={{ oracle_home }})(SID_NAME={{ oracle_sid }})))"
+        owner: "{{ grid_user }}"
+        group: "{{ oracle_group }}"
+      register: standby_listener_update
+      become: true
+      become_user: "{{ grid_user }}"
 
-    - name: Active-copy | Get primary db password file information
+    - name: Active-copy | Reload listener
+      shell: "{{ grid_home }}/bin/lsnrctl reload {{ listener_name }}"
+      environment:
+        ORACLE_HOME: "{{ grid_home }}"
+        PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ grid_user }}"
+      when: standby_listener_update.changed
+
+    - name: Active-copy | Create audit dump directory
+      file:
+        path: "{{ oracle_base }}/admin/{{ oracle_sid }}/adump"
+        state: directory
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wrx,go="
+
+    - name: Active-copy | Create auxiliary init file
+      template:
+        src: initaux.ora.j2
+        dest: "{{ oracle_home }}/dbs/init{{ oracle_sid }}.ora"
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wr,go="
+
+    - name: Active-copy | Start auxiliary instance
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        startup nomount pfile={{ oracle_home }}/dbs/init{{ oracle_sid }}.ora force
+        alter system register;
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: Active-copy | Get the primary database password file information
       shell: |
         set -o pipefail
         srvctl config db -d {{ db_name }} | grep "^Password file"
@@ -56,7 +102,7 @@
       changed_when: false
       register: srvctl_output
 
-    - name: Active-copy | Password file variable
+    - name: Active-copy | Extract password file name
       set_fact:
         password_file: "{{ srvctl_output.stdout | regex_replace('^Password file:') | regex_replace('\\s') }}"
 
@@ -110,7 +156,12 @@
       become_user: "{{ grid_user }}"
       when: password_file is search('^\\+')
 
-    - name: Active-copy | Set sys password for primary db
+    - name: Active-copy | Generate random password
+      set_fact:
+        sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
+      no_log: true
+
+    - name: Active-copy | Set sys password for primary database
       command:
         argv:
           - "{{ oracle_home }}/bin/orapwd"
@@ -125,57 +176,6 @@
       become: true
       become_user: "{{ oracle_user }}"
       no_log: true
-
-    - name: Active-copy | Add static listener entry
-      lineinfile:
-        path: "{{ grid_home }}/network/admin/listener.ora"
-        regexp: "^SID_LIST_{{ listener_name }}"
-        line: "SID_LIST_{{ listener_name }}=(SID_LIST=(SID_DESC=(GLOBAL_DBNAME={{ standby_name }}{% if db_domain | default('', true) | length > 0 %}.{{ db_domain }}{% endif %})(ORACLE_HOME={{ oracle_home }})(SID_NAME={{ oracle_sid }})))"
-        owner: "{{ grid_user }}"
-        group: "{{ oracle_group }}"
-      register: standby_listener_update
-      become: true
-      become_user: "{{ grid_user }}"
-
-    - name: Active-copy | Reload listener
-      shell: "{{ grid_home }}/bin/lsnrctl reload {{ listener_name }}"
-      environment:
-        ORACLE_HOME: "{{ grid_home }}"
-        PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-      become: true
-      become_user: "{{ grid_user }}"
-      when: standby_listener_update.changed
-
-    - name: Active-copy | Create audit dump directory
-      file:
-        path: "{{ oracle_base }}/admin/{{ oracle_sid }}/adump"
-        state: directory
-        owner: "{{ oracle_user }}"
-        group: "{{ oracle_group }}"
-        mode: "u=wrx,go="
-
-    - name: Active-copy | Create auxiliary init file
-      template:
-        src: initaux.ora.j2
-        dest: "{{ oracle_home }}/dbs/init{{ oracle_sid }}.ora"
-        owner: "{{ oracle_user }}"
-        group: "{{ oracle_group }}"
-        mode: "u=wr,go="
-
-    - name: Active-copy | Start auxiliary instance
-      shell: |
-        set -o pipefail
-        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
-        startup nomount pfile={{ oracle_home }}/dbs/init{{ oracle_sid }}.ora force
-        alter system register;
-        host sleep 60
-        EOF
-      environment:
-        ORACLE_HOME: "{{ oracle_home }}"
-        ORACLE_SID: "{{ oracle_sid }}"
-        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-      become: true
-      become_user: "{{ oracle_user }}"
 
     - name: Active-copy | Set sys password for auxiliary instance
       command:
@@ -216,6 +216,7 @@
         PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
       become: true
       become_user: "{{ oracle_user }}"
+      no_log: true
 
     - name: Active-copy | Add Oracle Restart configuration
       shell: |

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -50,7 +50,9 @@
       become_user: "{{ grid_user }}"
 
     - name: Active-copy | Reload listener
-      shell: "{{ grid_home }}/bin/lsnrctl reload {{ listener_name }}"
+      shell: |
+        {{ grid_home }}/bin/lsnrctl reload {{ listener_name }}
+        sleep 60
       environment:
         ORACLE_HOME: "{{ grid_home }}"
         PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
@@ -91,7 +93,7 @@
     - name: Active-copy | Get the primary database password file information
       shell: |
         set -o pipefail
-        srvctl config db -d {{ db_name }} | grep "^Password file"
+        (srvctl config db -d {{ db_name }} || true) | grep "^Password file"
       environment:
         ORACLE_HOME: "{{ oracle_home }}"
         ORACLE_SID: "{{ oracle_sid }}"

--- a/roles/db-copy/templates/duplicate.cmd.j2
+++ b/roles/db-copy/templates/duplicate.cmd.j2
@@ -1,5 +1,8 @@
-duplicate target database for standby from active database
-spfile
-  set "db_unique_name"="{{ db_name }}{{ standby_suffix }}"
-section size {{ section_size | default('32G', true) }}
-{% if oracle_ver_base != '11.2' %}using {% if backupset_compression | default(false) | bool %}compressed{% endif %} backupset{% endif %};
+DUPLICATE TARGET DATABASE
+  FOR STANDBY
+  FROM ACTIVE DATABASE
+  DORECOVER
+  SPFILE
+    SET db_unique_name="{{ standby_name }}"
+  SECTION SIZE {{ section_size | default('32G', true) }}
+  {% if oracle_ver_base != '11.2' %}USING {% if backupset_compression | default(false) | bool %}COMPRESSED{% endif %} BACKUPSET{% endif %};

--- a/roles/db-copy/templates/initaux.ora.j2
+++ b/roles/db-copy/templates/initaux.ora.j2
@@ -1,2 +1,2 @@
-db_name={{ db_name }}
-db_unique_name={{ db_name }}{{ standby_suffix }}
+*.db_name={{ db_name }}
+*.db_unique_name={{ standby_name }}


### PR DESCRIPTION
## Change Description:

The change optimizes (added compatibility fixes and other enhancements) the RMAN active-copy phase of the Oracle Data Guard setup tasks.

Specific adjustments include:

1. Defining the standby database name in a new `standby_name` Ansible variable. Previously, the composite of `{{ db_name }}{{ standby_suffix }}` was used. However, it was used in many locations and the number of usages is growing with Data Guard task step improvements. Consequently it makes sense to define, and use the new variable.
1. Update the `active-copy.yml` task file for idempotency. Including first checking the state of an existing database, and only performing the active duplication tasks if an existing, and clusterware registered database is not present. Regardless of whether the setup was performed, or skipped, the state of the standby database is shown at then end of the task file tasks. With these changes, if the database is present and registered with the clusterware, the task-file is now completely idempotent (meaning a PLAY RECAP with `changed=0`).
1. As of Oracle 21c the default location of the password file changes from `$ORACLE_HOME/dbs` to `$ORACLE_BASE/dbs`. Therefore tasks are updated to first check for a password file in a custom (and clusterware registered) location, then the Oracle Home location, and finally the Oracle Base location.
1. Move password file to ASM for standby instance.
1. Perform other database adjustments (from the `db-adjustments` role) to ensure that block change tracking and force logging is enabled on the standby. Otherwise, in the event of a Data Guard switch-over, the newly prompted environment does not match the characteristics of the original database.
1. Listener is only reloaded if changed.
1. Redundant `become:` task keys removed as a clean-up activity. Playbook, and consequently this task-file is run as root and therefore `become` is only required when accompanied by a `become_user` key-value.

## Test Results:

Tested against Oracle Database versions 21c, 19c, 18c, and 12gR2 on Oracle Linux 8:

- [Oracle Database 21c Test Run Output](https://gist.github.com/simonpane/955f406a5a1464cf7f6cdc4c0ccdf9d2)
- [Oracle Database 19c Test Run Output](https://gist.github.com/simonpane/4b7a72fd2acf498375307aa6eada3e0d)
- [Oracle Database 18c Test Run Output](//gist.github.com/simonpane/b82ebf3c2ab58c6084fade0c88c99bdf)
- [Oracle Database 12gR2 Test Run Output](https://gist.github.com/simonpane/d431655554048f360b8e96182ac59631)
