### PR TITLE
Add a warning about passwords in debug logs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2178,7 +2178,8 @@ instance is created.</td>
 --debug
 </pre></p></td>
 <td></td>
-<td>Run with the Ansible debugging flag enabled.</td>
+<td>Run with the Ansible debugging flag enabled.  With debugging
+enabled, passwords appear in logfiles.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Quoting https://docs.ansible.com/ansible/latest/reference_appendices/logging.html:

> To keep sensitive values out of your logs, mark tasks that expose them with the no_log: True attribute. However, the no_log attribute does not affect debugging output, so be careful not to debug playbooks in a production environment.