### PR TITLE
Updates to Data Guard setup and implementation steps

### DIFF
--- a/config-db.yml
+++ b/config-db.yml
@@ -58,6 +58,5 @@
     - include_role:
         name: dg-config
         tasks_from: main
-      when:
-        - cluster_type == "DG"
+      when: cluster_type == "DG"
       tags: dg-create

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -109,7 +109,7 @@ prereq_option: "{% if oracle_ver_base in ('11.2', '12.1') %}-ignorePrereq{% else
 # and set it to the suffix which identifies location of the standby database
 # (like "_sydney" for example)
 # The same suffix will be "attached" to the db name in DG configuration as well.
-standby_suffix: _s
+standby_name: "{{ db_name }}_s"
 
 # section size to use during RMAN duplicate
 section_size: 32G

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -13,196 +13,189 @@
 # limitations under the License.
 
 ---
-- name: DG | SQL to add standby logs
-  set_fact:
-    sql_for_dg: |
-      alter system set dg_broker_start=true sid='*';
-      alter system set standby_file_management=auto sid='*';
-      begin
-         for c in (select bytes, thr, (max(cnt_log) - nvl(max(cnt_sby), 0)) diff
-                     from (select bytes, thread# thr, count(*) cnt_log, null cnt_sby from v\$log group by bytes, thread#
-                           union all
-                           select bytes, thread# thr, null cnt_log, count(*) cnt_sby from v\$standby_log group by bytes, thread#
-                          )
-                    group by bytes, thr
-                  ) loop
-           for n in 1..c.diff + 1 loop
-               execute immediate 'alter database add standby logfile thread '||c.thr||' size '||c.bytes;
-           end loop;
-         end loop;
-      end;
-      /
-  tags: dg-create
-
-- name: DG | Enable force logging, set DG parameters and create standby logs on primary
-  # start DG broker
-  # enable force logging
-  # add +1 standby redo groups
+- name: DG | Check if the Data Guard configuration already exists
   shell: |
     set -o pipefail
-    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
-    begin
-       for c in (select force_logging from v\$database) loop
-          if c.force_logging = 'NO' then
-             execute immediate 'alter database force logging';
-          end if;
-       end loop;
-    end;
-    /
-    {{ sql_for_dg }}
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  delegate_to: primary1
-  become: true
-  become_user: "{{ oracle_user }}"
-  register: db_change
-  tags: dg-create
-
-- name: DG | Set DG parameters and create standby logs on standby
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
-    {{ sql_for_dg }}
-    EOF
+    ({{ oracle_home }}/bin/dgmgrl -silent / "show configuration" || true) | awk '/Configuration Status:/ {getline; print $1}'
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
   become: true
   become_user: "{{ oracle_user }}"
-  register: db_change
+  changed_when: false
+  register: current_dg_status
   tags: dg-create
 
-- name: DG | Script for DG setup
-  template:
-    src: dg-create.j2
-    dest: "{{ oracle_home }}/dbs/create_dg_{{ db_name }}.cmd"
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
-    mode: "u=wr,go="
-  delegate_to: primary1
-  become: true
-  become_user: "{{ oracle_user }}"
+- name: DG | Run Data Guard setup tasks
+  when: current_dg_status.stdout | upper != "SUCCESS"
   tags: dg-create
+  block:
+    - name: DG | Define SQL commands to add standby redo logs
+      set_fact:
+        sql_for_dg: |
+          alter system set dg_broker_start=true sid='*';
+          alter system set standby_file_management=auto sid='*';
+          begin
+            for c in (select bytes, thr, (max(cnt_log) - nvl(max(cnt_sby), 0)) diff
+                        from (select bytes, thread# thr, count(*) cnt_log, null cnt_sby from v\$log group by bytes, thread#
+                              union all
+                              select bytes, thread# thr, null cnt_log, count(*) cnt_sby from v\$standby_log group by bytes, thread#
+                              )
+                        group by bytes, thr
+                      ) loop
+              for n in 1..c.diff + 1 loop
+                  execute immediate 'alter database add standby logfile thread '||c.thr||' size '||c.bytes;
+              end loop;
+            end loop;
+          end;
+          /
 
-- name: DG | Create DG configuration
+    - name: DG | Enable force logging, set DG parameters and create standby redo logs on the primary
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        begin
+          for c in (select force_logging from v\$database) loop
+              if c.force_logging = 'NO' then
+                execute immediate 'alter database force logging';
+              end if;
+          end loop;
+        end;
+        /
+        {{ sql_for_dg }}
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: DG | Set DG parameters and create standby redo logs on the standby
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        {{ sql_for_dg }}
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: DG | Reset the password file on both servers
+      include_role:
+        name: dg-config
+        tasks_from: orapw_copy
+      when: oracle_ver_base | float > 19.3
+
+    - name: DG | Copy script for creating the Data Guard configuration
+      template:
+        src: dg-create.j2
+        dest: "{{ oracle_home }}/dbs/create_dg_{{ db_name }}.cmd"
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: "u=wr,go="
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: DG | Run script to create the Data Guard configuration
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/dgmgrl <<EOF
+        {% if oracle_ver_base | float > 19.3 %}
+        connect sys/{{ sys_pass }}
+        {% else %}
+        connect /
+        {% endif %}
+        @"{{ oracle_home }}/dbs/create_dg_{{ db_name }}.cmd"
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      delegate_to: primary1
+      become: true
+      become_user: "{{ oracle_user }}"
+      register: dg_create
+      no_log: true
+
+    - name: DG | Define SQL commands for pre-19c standby parameter adjustments
+      set_fact:
+        sql_for_standby: |
+          alter system set archive_lag_target=0 sid='*' scope=both;
+          alter system set log_archive_max_processes=4 sid='*' scope=both;
+          alter system set log_archive_min_succeed_dest=1 sid='*' scope=both;
+          alter system set data_guard_sync_latency=0 sid='*' scope=both;
+      when: oracle_ver_base | float <= 18.0
+
+    - name: DG | Set other DG parameters on the standby
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+        {{ sql_for_standby }}
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+      when: oracle_ver_base | float <= 18.0
+
+    - name: DG | Restart standby if required
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/sqlplus / as sysdba <<EOF
+        shutdown immediate
+        startup mount
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+      when: "'database instance restart required' in dg_create.stdout"
+
+    - name: DG | Enable standby database after restart to clear warnings
+      shell: |
+        set -o pipefail
+        {{ oracle_home }}/bin/dgmgrl / <<EOF
+        enable database {{ standby_name }};
+        host sleep 60;
+        show database verbose {{ standby_name }};
+        EOF
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      become: true
+      become_user: "{{ oracle_user }}"
+      when: "'database instance restart required' in dg_create.stdout"
+
+- name: DG | Capture Data Guard configuration
   shell: |
     set -o pipefail
     {{ oracle_home }}/bin/dgmgrl / <<EOF
-    @"{{ oracle_home }}/dbs/create_dg_{{ db_name }}.cmd"
+    show configuration verbose;
     EOF
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  delegate_to: primary1
   become: true
   become_user: "{{ oracle_user }}"
-  register: dg_create
+  changed_when: false
+  register: dg_config
   tags: dg-create
 
-- name: DG | DG creation output
+- name: DG | Show Data Guard configuration
   debug:
-    var: dg_create.stdout_lines
+    var: dg_config.stdout_lines
     verbosity: 0
-  tags: dg-create
-
-- name: DG | Wait for DG to be enabled
-  command: "sleep 60"
-  tags: dg-create
-
-- name: DG | Show DG configuration
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl / << EOF
-    show configuration verbose
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
-  register: dg_create
-  tags: dg-create
-
-- name: DG | DG verbose output
-  debug:
-    var: dg_create.stdout_lines
-    verbosity: 0
-  tags: dg-create
-
-- name: DG | Show standby database configuration
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl / <<EOF
-    show database verbose {{ db_name }}{{ standby_suffix }}
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
-  register: dg_standby
-  tags: dg-create
-
-- name: DG | Restart standby if required
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/sqlplus / as sysdba <<EOF
-    shutdown immediate
-    startup mount
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when: "'database instance restart required' in dg_standby.stdout"
-  become: true
-  become_user: "{{ oracle_user }}"
-  tags: dg-create
-
-- name: DG | Enable standby database after restart to clear warnings
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl / <<EOF
-    enable database {{ db_name }}{{ standby_suffix }};
-    show database verbose {{ db_name }}{{ standby_suffix }};
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when: "'database instance restart required' in dg_standby.stdout"
-  become: true
-  become_user: "{{ oracle_user }}"
-  register: dg_standby
-  tags: dg-create
-
-- name: DG | Add Oracle Restart configuration
-  shell: |
-    set -o pipefail
-    srvctl add db -d {{ db_name }}{{ standby_suffix }} \
-      -oraclehome {{ oracle_home }} {% if db_domain | default('', true) | length > 0 %}-domain {{ db_domain }}{% endif %} \
-      -spfile {{ oracle_home }}/dbs/spfile{{ db_name }}.ora \
-      -pwfile {{ oracle_home }}/dbs/orapw{{ db_name }} \
-      -role PHYSICAL_STANDBY \
-      -startoption MOUNT \
-      -stopoption IMMEDIATE \
-      -instance {{ oracle_sid }} \
-      -dbname {{ db_name }}
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
-  register: db_config
-  failed_when:
-    - "(db_config.rc not in [2]) or ('already exists' not in db_config.stdout)"
-    - db_config.rc not in [0]
   tags: dg-create

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -87,9 +87,8 @@
       become_user: "{{ oracle_user }}"
 
     - name: DG | Reset the password file on both servers
-      include_role:
-        name: dg-config
-        tasks_from: orapw_copy
+      include_tasks:
+        file: orapw_copy.yml
       when: oracle_ver_base | float > 19.3
 
     - name: DG | Copy script for creating the Data Guard configuration

--- a/roles/dg-config/tasks/orapw_copy.yml
+++ b/roles/dg-config/tasks/orapw_copy.yml
@@ -1,0 +1,62 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: DG orapwd | Generate random password
+  set_fact:
+    sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
+  no_log: true
+
+- name: DG orapwd | Set sys password for primary database
+  command:
+    argv:
+      - "{{ oracle_home }}/bin/orapwd"
+      - "file={{ oracle_base }}/dbs/orapw{{ db_name }}"
+      - "force=y"
+      - "password={{ sys_pass }}"
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_BASE: "{{ oracle_base }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  delegate_to: primary1
+  become: true
+  become_user: "{{ oracle_user }}"
+  no_log: true
+
+- name: DG orapwd | Create a temporary file for transfer
+  tempfile:
+    state: file
+  register: temp_file
+
+- name: DG orapwd | Fetch password file from primary
+  fetch:
+    src: "{{ oracle_base }}/dbs/orapwORCL"
+    dest: "{{ temp_file.path }}"
+    flat: true
+  delegate_to: primary1
+
+- name: DG orapwd | Copy password file to standby
+  copy:
+    src: "{{ temp_file.path }}"
+    dest: "{{ oracle_base }}/dbs/orapwORCL"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+    mode: "u=wr,go="
+
+- name: DG orapwd | Remove temporary file
+  file:
+    path: "{{ temp_file.path }}"
+    state: absent
+  when: temp_file.path is defined

--- a/roles/dg-config/templates/dg-create.j2
+++ b/roles/dg-config/templates/dg-create.j2
@@ -2,9 +2,11 @@ CREATE CONFIGURATION dg_{{ db_name }} AS
 PRIMARY DATABASE IS {{ db_name }}
 CONNECT IDENTIFIER IS "//{{ hostvars['primary1'].ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}";
 
-ADD DATABASE {{ db_name }}{{ standby_suffix }}
-AS CONNECT IDENTIFIER IS "//{{ ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}";
+ADD DATABASE {{ standby_name }}
+AS CONNECT IDENTIFIER IS "//{{ ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ standby_name }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}";
 
 ENABLE CONFIGURATION;
+HOST sleep 60;
 
 SHOW CONFIGURATION VERBOSE;
+SHOW DATABASE VERBOSE {{ standby_name }};


### PR DESCRIPTION
## Change Description:

> **IMPORTANT:** To be merged after [https://github.com/google/oracle-toolkit/pull/238](https://github.com/google/oracle-toolkit/pull/238)

Enhancements and changes required for Data Guard configuration.

For older versions (pre-19c):

- Manually setting of initialization parameters on the standby database is required. Otherwise the configuration will show "`Warning: ORA-16792: configuration property value is inconsistent with database setting`" error.
- Adjusted delays required (where and when delays of 60 seconds happen) for the Data Guard configuration to "_catch-up_" with the current state so that at the end of the play, the `show configuration` command will show `SUCCESS`.

For newer versions (beyond 19c), the process for creating the Data Guard configuration has changed:

- Must now connect using the `sys` user with password. Connecting simply using `/` without a password will no longer suffice.
- Since, by using the `--tags dg-create` option, the Data Guard configuration tasks can be run independently of the other playbook sections, the previously used value for `sys_pass` (set during the `db-copy` role) cannot be guaranteed to be defined and hence must be re-created.
- Additionally, the `orapwd` file must be a binary copy from the primary to the standby. Otherwise an `ORA-1033: ORACLE initialization or shutdown in progress` error will be displayed when trying to add the standby to the configuration.
- Default location of the password file has moved from `$ORACLE_HOMB/dbs` to `$ORACLE_BASE/dbs`.

Finally, this change includes general optimizations including:

- Making the Data Guard implementation tasks fully idempotent (meaning a PLAY RECAP with `changed=0`).
- Displaying the configuration status (output of `show configuration verbose`) as a final step to have meaningful information in STDOUT.
- Added the `no_log: true` key-value to all relevant steps that use the SYS password.

> NOTE: For the older releases, it can take up to 5 minutes for the standby to catch up and not report an apply-lag error after a restart - during which time the configuration will report a **WARNING** status. Rather than have the toolkit wait for this, can add this explanation to the Data Guard documentation.

## Test Results:

Tested against Oracle Database versions 21c, 19c, 18c, and 12gR2 on Oracle Linux 8:

- [Oracle Database 21c Test Run Output](https://gist.github.com/simonpane/9a317fb7a6e097f179f14f266225e289)
- [Oracle Database 19c Test Run Output](https://gist.github.com/simonpane/33f6a00b5bb04e1792c0e0492f09adfc)
- [Oracle Database 18c Test Run Output](https://gist.github.com/simonpane/ca415efca2c14bbcc149153e89a2bcf1)
- [Oracle Database 12gR2 Test Run Output](https://gist.github.com/simonpane/35d9b0803f0b83161a7a991ad63ccbc6)
