### PR TITLE
Add task file with tasks for changing the DG protection level and redo transport mode

### DIFF
--- a/config-db.yml
+++ b/config-db.yml
@@ -61,3 +61,9 @@
       when:
         - cluster_type == "DG"
       tags: dg-create
+
+    - include_role:
+        name: dg-config
+        tasks_from: dg_mode
+      when: cluster_type == "DG"
+      tags: dg-create,dg-mode

--- a/roles/dg-config/defaults/main.yml
+++ b/roles/dg-config/defaults/main.yml
@@ -16,3 +16,4 @@
 # Specify one of the Data Guard protection modes: MAXPERFORMANCE, MAXAVAILABILITY, or MAXPROTECTION
 data_guard_protection_mode: "MAXAVAILABILITY"
 real_time_apply: true
+log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXPERFORMANCE' else 'SYNC' }}"

--- a/roles/dg-config/defaults/main.yml
+++ b/roles/dg-config/defaults/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Specify one of the Data Guard protection modes: MAXPERFORMANCE, MAXAVAILABILITY, or MAXPROTECTION
+data_guard_protection_mode: "MAXAVAILABILITY"
+real_time_apply: true

--- a/roles/dg-config/defaults/main.yml
+++ b/roles/dg-config/defaults/main.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-# Specify one of the Data Guard protection modes: MAXPERFORMANCE, MAXAVAILABILITY, or MAXPROTECTION
-data_guard_protection_mode: "MAXAVAILABILITY"
+# Specify one of the Data Guard protection modes: "Maximum Performance", "Maximum Availability", or "Maximum Protection"
+data_guard_protection_mode: "Maximum Availability"
 real_time_apply: true
-log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXPERFORMANCE' else 'SYNC' }}"
+log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXIMUM PERFORMANCE' else 'SYNC' }}"

--- a/roles/dg-config/tasks/dg_mode.yml
+++ b/roles/dg-config/tasks/dg_mode.yml
@@ -30,7 +30,7 @@
 - name: DG Mode | Validate whether the desired protection mode change is possible
   assert:
     that:
-      - not (current_dg_mode.stdout | upper == "MAXPERFORMANCE" and data_guard_protection_mode | upper == "MAXPROTECTION")
+      - not (current_dg_mode.stdout | upper == "MAXPERFORMANCE" and data_guard_protection_mode | upper == "MAXIMUM PROTECTION")
     quiet: true
     fail_msg: "ERROR: Cannot change from MAXIMUM PERFORMANCE directly to MAXIMUM PROTECTION - must change to MAXIMUM AVAILABILITY first"
   tags: dg-mode,dg-create
@@ -72,13 +72,13 @@
   shell: |
     set -o pipefail
     {{ oracle_home }}/bin/dgmgrl / <<EOF
-    edit configuration set protection mode as {{ data_guard_protection_mode }};
+    edit configuration set protection mode as {{ data_guard_protection_mode | replace(' ', '') | replace('imum', '') | upper }};
     EOF
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when: current_dg_mode.stdout | upper != data_guard_protection_mode | upper
+  when: current_dg_mode.stdout | upper != data_guard_protection_mode | replace(' ', '') | replace('imum', '') | upper
   become: true
   become_user: "{{ oracle_user }}"
   tags: dg-mode,dg-create

--- a/roles/dg-config/tasks/dg_mode.yml
+++ b/roles/dg-config/tasks/dg_mode.yml
@@ -35,10 +35,10 @@
     fail_msg: "ERROR: Cannot change from MAXIMUM PERFORMANCE directly to MAXIMUM PROTECTION - must change to MAXIMUM AVAILABILITY first"
   tags: dg-mode,dg-create
 
-- name: DG Mode | Capture the current redo transport mode for the primary
+- name: DG Mode | Capture the current redo transport mode
   shell: |
     set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl -silent / "show database {{ db_name }} 'LogXptMode'" | grep "LogXptMode" | awk -F" " '{ print $3 }' | sed "s/'//g"
+    {{ oracle_home }}/bin/dgmgrl -silent / "show database {{ item }} 'LogXptMode'" | grep "LogXptMode" | awk -F" " '{ print $3 }' | sed "s/'//g"
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
@@ -46,89 +46,26 @@
   become: true
   become_user: "{{ oracle_user }}"
   changed_when: false
-  register: primary_logxpt_mode
+  register: db_logxpt_mode
+  with_items:
+    - "{{ db_name }}"
+    - "{{ standby_name }}"
   tags: dg-mode,dg-create
 
-- name: DG Mode | Change the redo transport mode to SYNC on the primary
+- name: DG Mode | Change the redo transport mode to {{ log_transport_mode }}
   shell: |
     set -o pipefail
     {{ oracle_home }}/bin/dgmgrl / <<EOF
-    edit database {{ db_name }} set property 'LogXptMode'='SYNC';
+    edit database {{ item.db_name }} set property 'LogXptMode'='{{ log_transport_mode }}';
     EOF
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when:
-    - data_guard_protection_mode | upper != 'MAXPERFORMANCE'
-    - primary_logxpt_mode.stdout | upper != 'SYNC'
+  when: item.current_transfer_mode | upper != log_transport_mode
   become: true
   become_user: "{{ oracle_user }}"
-  tags: dg-mode,dg-create
-
-- name: DG Mode | Change the redo transport mode to ASYNC on the primary
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl / <<EOF
-    edit database {{ db_name }} set property 'LogXptMode'='ASYNC';
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when:
-    - data_guard_protection_mode | upper == 'MAXPERFORMANCE'
-    - primary_logxpt_mode.stdout | upper != 'ASYNC'
-  become: true
-  become_user: "{{ oracle_user }}"
-  tags: dg-mode,dg-create
-
-- name: DG Mode | Capture the current redo transport mode for the standby
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl -silent / "show database {{ standby_name }} 'LogXptMode'" | grep "LogXptMode" | awk -F" " '{ print $3 }' | sed "s/'//g"
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  become: true
-  become_user: "{{ oracle_user }}"
-  changed_when: false
-  register: standby_logxpt_mode
-  tags: dg-mode,dg-create
-
-- name: DG Mode | Change the redo transport mode to SYNC on the standby
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl / <<EOF
-    edit database {{ standby_name }} set property 'LogXptMode'='SYNC';
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when:
-    - data_guard_protection_mode | upper != 'MAXPERFORMANCE'
-    - standby_logxpt_mode.stdout | upper != 'SYNC'
-  become: true
-  become_user: "{{ oracle_user }}"
-  tags: dg-mode,dg-create
-
-- name: DG Mode | Change the redo transport mode to ASYNC on the standby
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/dgmgrl / <<EOF
-    edit database {{ standby_name }} set property 'LogXptMode'='ASYNC';
-    EOF
-  environment:
-    ORACLE_HOME: "{{ oracle_home }}"
-    ORACLE_SID: "{{ oracle_sid }}"
-    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  when:
-    - data_guard_protection_mode | upper == 'MAXPERFORMANCE'
-    - standby_logxpt_mode.stdout | upper != 'ASYNC'
-  become: true
-  become_user: "{{ oracle_user }}"
+  with_items: "{{ db_logxpt_mode | json_query('results[*].{db_name:item,current_transfer_mode:stdout}') }}"
   tags: dg-mode,dg-create
 
 - name: DG Mode | Change the Data Guard protection mode

--- a/roles/dg-config/tasks/dg_mode.yml
+++ b/roles/dg-config/tasks/dg_mode.yml
@@ -1,0 +1,233 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: DG Mode | Capture the current Data Guard protection mode
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl -silent / "show configuration" | grep "Protection Mode" | awk -F" " '{ print $3 }'
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: true
+  become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: current_dg_mode
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Validate whether the desired protection mode change is possible
+  assert:
+    that:
+      - not (current_dg_mode.stdout | upper == "MAXPERFORMANCE" and data_guard_protection_mode | upper == "MAXPROTECTION")
+    quiet: true
+    fail_msg: "ERROR: Cannot change from MAXIMUM PERFORMANCE directly to MAXIMUM PROTECTION - must change to MAXIMUM AVAILABILITY first"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Capture the current redo transport mode for the primary
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl -silent / "show database {{ db_name }} 'LogXptMode'" | grep "LogXptMode" | awk -F" " '{ print $3 }' | sed "s/'//g"
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: true
+  become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: primary_logxpt_mode
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Change the redo transport mode to SYNC on the primary
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / <<EOF
+    edit database {{ db_name }} set property 'LogXptMode'='SYNC';
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when:
+    - data_guard_protection_mode | upper != 'MAXPERFORMANCE'
+    - primary_logxpt_mode.stdout | upper != 'SYNC'
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Change the redo transport mode to ASYNC on the primary
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / <<EOF
+    edit database {{ db_name }} set property 'LogXptMode'='ASYNC';
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when:
+    - data_guard_protection_mode | upper == 'MAXPERFORMANCE'
+    - primary_logxpt_mode.stdout | upper != 'ASYNC'
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Capture the current redo transport mode for the standby
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl -silent / "show database {{ standby_name }} 'LogXptMode'" | grep "LogXptMode" | awk -F" " '{ print $3 }' | sed "s/'//g"
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: true
+  become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: standby_logxpt_mode
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Change the redo transport mode to SYNC on the standby
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / <<EOF
+    edit database {{ standby_name }} set property 'LogXptMode'='SYNC';
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when:
+    - data_guard_protection_mode | upper != 'MAXPERFORMANCE'
+    - standby_logxpt_mode.stdout | upper != 'SYNC'
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Change the redo transport mode to ASYNC on the standby
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / <<EOF
+    edit database {{ standby_name }} set property 'LogXptMode'='ASYNC';
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when:
+    - data_guard_protection_mode | upper == 'MAXPERFORMANCE'
+    - standby_logxpt_mode.stdout | upper != 'ASYNC'
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Change the Data Guard protection mode
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / <<EOF
+    edit configuration set protection mode as {{ data_guard_protection_mode }};
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when: current_dg_mode.stdout | upper != data_guard_protection_mode | upper
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Capture current apply mode
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+    SET heading OFF
+    SET termout OFF
+    SELECT recovery_mode FROM v\$archive_dest_status WHERE dest_id=2;
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  delegate_to: primary1
+  become: true
+  become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: current_apply_mode
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Show current apply mode
+  debug:
+    var: current_apply_mode.stdout
+    verbosity: 1
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Enable Real-Time Apply
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+    ALTER DATABASE RECOVER MANAGED STANDBY DATABASE DISCONNECT;
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when:
+    - real_time_apply
+    - not "'REAL TIME APPLY' in current_apply_mode.stdout"
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Disable Real-Time Apply
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+    ALTER DATABASE RECOVER MANAGED STANDBY DATABASE CANCEL;
+    ALTER DATABASE RECOVER MANAGED STANDBY DATABASE USING ARCHIVED LOGFILE DISCONNECT;
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when:
+    - not real_time_apply
+    - "'REAL TIME APPLY' in current_apply_mode.stdout"
+  become: true
+  become_user: "{{ oracle_user }}"
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Capture the current Data Guard configuration
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / <<EOF
+    show configuration verbose
+    show database verbose {{ db_name | lower }};
+    show database verbose {{ standby_name | lower }};
+    validate database {{ standby_name }};
+    show database {{ standby_name }} statusreport;
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: true
+  become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: dg_verification
+  tags: dg-mode,dg-create
+
+- name: DG Mode | Show output from inconsistency checks
+  debug:
+    var: dg_verification.stdout_lines
+    verbosity: 1
+  tags: dg-mode,dg-create

--- a/roles/dg-config/tasks/dg_mode.yml
+++ b/roles/dg-config/tasks/dg_mode.yml
@@ -229,5 +229,5 @@
 - name: DG Mode | Show output from inconsistency checks
   debug:
     var: dg_verification.stdout_lines
-    verbosity: 1
+    verbosity: 0
   tags: dg-mode,dg-create


### PR DESCRIPTION
## Change Description:

> **IMPORTANT:** To be merged after: [https://github.com/google/oracle-toolkit/pull/240](https://github.com/google/oracle-toolkit/pull/240)

Add new functionality to set the Data Guard Protection level and Apply Option using two new role specific variables:

- `data_guard_protection_mode` : range of values includes MAXPERFORMANCE, MAXAVAILABILITY, or MAXPROTECTION
- `real_time_apply` : a true/false boolean

This change includes:

1. Checking that the change in protection level is possible (i.e. cannot go directly from `MAXPERFORMANCE` to `MAXPROTECTION` as per Oracle documentation)
1. Performing the protection level change using the Data Guard Broker
1. Adjusting the log transport mode accordingly (i.e. `SYNC` or `ASYNC` depending on the chosen protection level)
1. Optionally showing the state of the configuration (with the "verbose" option) and each configuration member depending on verbosity

> NOTE: For the older releases (most commonly 18c), it can take a few minutes for the standby to catch up and not report an apply-lag error after a restart - during which time the configuration will report a **WARNING** status. Rather than have the toolkit wait for this, can add this explanation to the Data Guard documentation.

## Test Results:

Tested against Oracle Database versions 21c, 19c, 18c, and 12gR2 on Oracle Linux 8 (with verbosity level on final debug changed to show output of that task only):

- [Oracle Database 21c Test Run Output](https://gist.github.com/simonpane/a754758c352e058454ef0a159c5fe09a)
- [Oracle Database 19c Test Run Output](https://gist.github.com/simonpane/3f830471fea19b2ab2cbd7209384c2a0)
- [Oracle Database 18c Test Run Output](https://gist.github.com/simonpane/fab20fe6294bc5cbcbd46994fb465b7f)
- [Oracle Database 12gR2 Test Run Output](https://gist.github.com/simonpane/44ed39c62e9216fd5e444b81af66f318)
