### PR TITLE
Updates on NFS backup option.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1921,7 +1921,7 @@ BACKUP_DEST
 </pre></p></td>
 <td>user defined - no default<br>
 Example: +RECO</td>
-<td>Disk group name or NFS file share location. Can include formatting options,
+<td>Disk group name, filesystem  or NFS file share location. Can include formatting options,
 such as "/u02/db_backups/ORCL_%I_%T_%s_%p.bak", for example.<br>
 <br>
 When writing to a non-ASM disk group location, include a valid RMAN format
@@ -1930,9 +1930,32 @@ shown above.<br>
 <br>
 If you are writing to a local file system, the
 directory does not have to exist, but initial backups will fail if the
-destination is not available or writeable.
+destination is not available or writeable.<br>
 <br>
-If you are writing to a gcsfuse bucket, the /gcsfuse must be used as parameter.</td>
+If you are writing to a NFS share, the NFS share directory uid and gid should be configured to match your ownership needs. The NFS option requires the --nfs-backup-config option.</td>
+</tr>
+<br>
+If you are writing to a gcsfuse bucket, the /mnt must be used as parameter.</td>
+</tr>
+<tr>
+<td>NFS backup configuration</td>
+<td><p><pre>
+NFS_BACKUP_CONFIG
+--nfs-backup-config
+</pre></p></td>
+<td>user defined - no default<br>
+Example: vers=3 </td>
+<td>The NFS version of the export shared is defined with this option. The values accepted are ( vers=3 | vers=4 ).<br>
+</tr>
+<tr>
+<td>NFS backup mount</td>
+<td><p><pre>
+NFS_BACKUP_MOUNT
+--nfs-backup-mount
+</pre></p></td>
+<td>user defined - no default<br>
+Example: remote-nfs-server:/nfs/backup </td>
+<td>The nfs remote share expected as [remote-nfs-server-name]:[/remote-share-mount] .<br>
 </tr>
 <tr>
 <td>GCS backup configuration</td>

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -97,6 +97,8 @@ gcsfuse_backup_bucket_folder: "{{ lookup('env','GCS_BACKUP_BUCKET')|default('',t
 gcsfuse_backup_temp_path: "{{ lookup('env','GCS_BACKUP_TEMP_PATH')|default('',true) }}"
 gcsfuse_backup_path: "{{ lookup('env','GCS_BACKUP_PATH')|default('',true) }}"
 gcsfuse_backup_mount_path: "{{ lookup('env','BACKUP_DEST')|default('',true) }}"
+nfs_backup_config: "{{ lookup('env','NFS_BACKUP_CONFIG') }}"
+nfs_backup_mount: "{{ lookup('env','NFS_BACKUP_MOUNT') }}"
 rman_db_bu_redundancy: "{{ lookup('env','BACKUP_REDUNDANCY')|default('2',true) }}"
 rman_arch_redundancy: "{{ lookup('env','ARCHIVE_REDUNDANCY')|default('2',true) }}"
 rman_archs_online_days: "{{ lookup('env','ARCHIVE_ONLINE_DAYS')|default('7',true) }}"

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -193,6 +193,12 @@ GCS_BACKUP_BUCKET_PARAM="^.+[^/]"
 GCS_BACKUP_TEMP_PATH="${GCS_BACKUP_TEMP_PATH:-/u01/gcsfusetmp}"
 GCS_BACKUP_TEMP_PATH_PARAM="^/.*" 
 
+NFS_BACKUP_CONFIG="${NFS_BACKUP_CONFIG}"
+NFS_BACKUP_CONFIG_PARAM="^(vers=3|vers=4)$"
+
+NFS_BACKUP_MOUNT="${NFS_BACKUP_MOUNT}"
+NFS_BACKUP_MOUNT_PARAM="^[[:alnum:][:punct:]]*:[[:alnum:][:punct:]]*$"
+
 ARCHIVE_REDUNDANCY="${ARCHIVE_REDUNDANCY:-2}"
 ARCHIVE_REDUNDANCY_PARAM="^[0-9]+$"
 
@@ -251,7 +257,7 @@ COMPATIBLE_RDBMS_PARAM="^[0-9][0-9]\.[0-9].*"
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 ###
 GETOPT_MANDATORY="ora-swlib-bucket:"
-GETOPT_OPTIONAL="gcs-backup-config:,gcs-backup-bucket:,gcs-backup-temp-path:,backup-dest:,ora-version:,no-patch,ora-edition:,cluster-type:,cluster-config:,cluster-config-json:"
+GETOPT_OPTIONAL="gcs-backup-config:,gcs-backup-bucket:,gcs-backup-temp-path:,nfs-backup-config:,nfs-backup-mount:,backup-dest:,ora-version:,no-patch,ora-edition:,cluster-type:,cluster-config:,cluster-config-json:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-staging:,ora-db-name:,ora-db-domain:,ora-db-charset:,ora-disk-mgmt:,ora-role-separation:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-data-destination:,ora-data-diskgroup:,ora-reco-destination:,ora-reco-diskgroup:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-asm-disks:,ora-asm-disks-json:,ora-data-mounts:,ora-data-mounts-json:,ora-listener-port:,ora-listener-name:"
@@ -426,6 +432,14 @@ while true; do
     ;;
   --gcs-backup-temp-path)
     GCS_BACKUP_TEMP_PATH="$2"
+    shift
+    ;;
+  --nfs-backup-config)
+    NFS_BACKUP_CONFIG="$2"
+    shift
+    ;;
+  --nfs-backup-mount)
+    NFS_BACKUP_MOUNT="$2"
     shift
     ;;
   --backup-redundancy)
@@ -700,6 +714,14 @@ shopt -s nocasematch
   echo "Incorrect parameter provided for gcs-backup-temp-path: $GCS_BACKUP_TEMP_PATH"
   exit 1
 }
+[[ -n "$NFS_BACKUP_CONFIG" && ! "$NFS_BACKUP_CONFIG" =~ $NFS_BACKUP_CONFIG_PARAM ]] && [[ "${!BACKUP_DEST:0:1}" == "/" ]] && {
+  echo "Incorrect parameter provided for nfs-backup-config: $NFS_BACKUP_CONFIG"
+  exit 1
+}
+[[ -n "$NFS_BACKUP_MOUNT" && ! "$NFS_BACKUP_MOUNT" =~ $NFS_BACKUP_MOUNT_PARAM && -n "$NFS_BACKUP_CONFIG" ]] && {
+  echo "Incorrect parameter provided for nfs-backup-mount: $NFS_BACKUP_MOUNT"
+  exit 1
+}
 [[ ! "$BACKUP_REDUNDANCY" =~ $BACKUP_REDUNDANCY_PARAM ]] && {
   echo "Incorrect parameter provided for backup-redundancy: $BACKUP_REDUNDANCY"
   exit 1
@@ -946,6 +968,8 @@ export BACKUP_DEST
 export GCS_BACKUP_CONFIG
 export GCS_BACKUP_BUCKET
 export GCS_BACKUP_TEMP_PATH
+export NFS_BACKUP_CONFIG
+export NFS_BACKUP_MOUNT
 export BACKUP_LEVEL0_DAYS
 export BACKUP_LEVEL1_DAYS
 export BACKUP_LOG_LOCATION

--- a/roles/db-backups/defaults/main.yml
+++ b/roles/db-backups/defaults/main.yml
@@ -30,5 +30,7 @@ gcsfuse_backup_temp_prefix: "gcsfusetmp"
 gcsfuse_backup_mount_prefix: "gcsfuse"
 gcsfuse_bucket_prefix: "fusebackup"
 
+nfs_mount_params: "user,_netdev,rsize=32768,wsize=32768,timeo=14,intr"
+
 # backup_mount_src: ""
 # backup_mount_path: ""

--- a/roles/db-backups/defaults/main.yml
+++ b/roles/db-backups/defaults/main.yml
@@ -30,7 +30,5 @@ gcsfuse_backup_temp_prefix: "gcsfusetmp"
 gcsfuse_backup_mount_prefix: "gcsfuse"
 gcsfuse_bucket_prefix: "fusebackup"
 
-nfs_mount_params: "user,_netdev,rsize=32768,wsize=32768,timeo=14,intr"
-
 # backup_mount_src: ""
 # backup_mount_path: ""

--- a/roles/db-backups/tasks/main.yml
+++ b/roles/db-backups/tasks/main.yml
@@ -30,8 +30,9 @@
 - name: backup location | nfs mount
   include_tasks: nfs.yml
   when:
-    - backup_mount_src is defined
-    - backup_mount_path is defined
+    - nfs_backup_config | length > 0
+    - nfs_backup_mount | length > 0
+  tags: db-backups,add-backups
 
 - name: gcs backup location | gcs backup
   include_tasks: gcsmanual.yml

--- a/roles/db-backups/tasks/nfs.yml
+++ b/roles/db-backups/tasks/nfs.yml
@@ -33,18 +33,29 @@
 
 - name: nfs_backups | Create a nfs backups mount folder
   file:
-    path: "{{ backup_dest }}"
+    path: "{{ backup_dest }}/{{ db_name }}"
     state: directory
     mode: u=rwx,go=rx
     owner: "{{ oracle_user}}"
     group: backupdba
+
+- name: NFS values | Display NFS values
+  debug:
+    msg:
+      - "{{ backup_dest }}/{{ db_name }}"
+      - "{{ nfs_backup_config }},{{ nfs_mount_params }}"
+      - "{{ nfs_backup_mount }}"
 
 - name: nfs_backups | Mount NFS share (backup)
   become: true
   become_user: root
   mount:
     fstype: nfs
-    name: "{{ backup_dest }}"
-    opts: "user,vers=3,_netdev,rsize=8192,wsize=8192,timeo=14,intr"
-    src: "{{ backup_src }}"
+    name: "{{ backup_dest }}/{{ db_name }}"
+    opts: "{{ nfs_backup_config }},{{ nfs_mount_params }}"
+    src: "{{ nfs_backup_mount }}"
     state: mounted
+
+- name: nfs set backup directory | NFS set backup directory
+  set_fact:
+    backup_dest: "{{ backup_dest }}/{{ db_name }}"

--- a/roles/db-backups/tasks/nfs.yml
+++ b/roles/db-backups/tasks/nfs.yml
@@ -39,20 +39,13 @@
     owner: "{{ oracle_user}}"
     group: backupdba
 
-- name: NFS values | Display NFS values
-  debug:
-    msg:
-      - "{{ backup_dest }}/{{ db_name }}"
-      - "{{ nfs_backup_config }},{{ nfs_mount_params }}"
-      - "{{ nfs_backup_mount }}"
-
 - name: nfs_backups | Mount NFS share (backup)
   become: true
   become_user: root
   mount:
     fstype: nfs
     name: "{{ backup_dest }}/{{ db_name }}"
-    opts: "{{ nfs_backup_config }},{{ nfs_mount_params }}"
+    opts: "user,{{ nfs_backup_config }},_netdev,rsize=32768,wsize=32768,timeo=14,intr"
     src: "{{ nfs_backup_mount }}"
     state: mounted
 

--- a/roles/db-backups/tasks/nfs.yml
+++ b/roles/db-backups/tasks/nfs.yml
@@ -39,13 +39,20 @@
     owner: "{{ oracle_user}}"
     group: backupdba
 
+- name: NFS values | Display NFS values
+  debug:
+    msg:
+      - "{{ backup_dest }}/{{ db_name }}"
+      - "{{ nfs_backup_config }},{{ nfs_mount_params }}"
+      - "{{ nfs_backup_mount }}"
+
 - name: nfs_backups | Mount NFS share (backup)
   become: true
   become_user: root
   mount:
     fstype: nfs
     name: "{{ backup_dest }}/{{ db_name }}"
-    opts: "user,{{ nfs_backup_config }},_netdev,rsize=32768,wsize=32768,timeo=14,intr"
+    opts: "{{ nfs_backup_config }},{{ nfs_mount_params }}"
     src: "{{ nfs_backup_mount }}"
     state: mounted
 


### PR DESCRIPTION
## Change Description:
Updating nfs backup option parameters and support. 

## Solution Overview:
This change is updating NFS backup option. The option now include parameters for NFS share and NFS version to be used as mount option. 

There are new validations to verify the mount point and the  nfs share to be mounted. 

The updated version was tested against previous backup options and with backup configuration change with the --config-db option. 

## Test Commands:
```bash
time ./install-oracle.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/19c --instance-ssh-user marcos --instance-ssh-key ~/.ssh/id_rsa --backup-dest "/mnt/nfs" --ora-swlib-path /u02/swlib/ --ora-version 19 --ora-swlib-type gcs --ora-asm-disks ~/asm_disk_config.json --ora-data-mounts ~/data_mounts_config.json --cluster-type NONE --ora-data-diskgroup DATA --ora-reco-diskgroup RECO --ora-db-name orcl --ora-db-container false --instance-ip-addr 10.2.80.105 --instance-hostname marcos-db-ol7-ub0e --allow-install-on-vm --no-patch  --nfs-backup-config vers=3 --nfs-backup-mount gmz-ansible-brew:/nfs/gcp 

time ./install-oracle.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/19c --instance-ssh-user marcos --instance-ssh-key ~/.ssh/id_rsa --backup-dest "/mnt/nfs" --ora-swlib-path /u02/swlib/ --ora-version 19 --ora-swlib-type gcs --ora-asm-disks ~/asm_disk_config.json --ora-data-mounts ~/data_mounts_config.json --cluster-type NONE --ora-data-diskgroup DATA --ora-reco-diskgroup RECO --ora-db-name orcl --ora-db-container false --instance-ip-addr 10.2.80.109 --instance-hostname marcos-db-ol8-sdnz --allow-install-on-vm --no-patch --nfs-backup-config vers=3 --nfs-backup-mount gmz-ansible-brew:/nfs/gcp 
```
```bash
time ./install-oracle.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/19c --instance-ssh-user marcos --instance-ssh-key ~/.ssh/id_rsa --backup-dest "/mnt/nfs" --ora-swlib-path /u02/swlib/ --ora-version 19 --ora-swlib-type gcs --ora-asm-disks ~/asm_disk_config.json --ora-data-mounts ~/data_mounts_config.json --cluster-type NONE --ora-data-diskgroup DATA --ora-reco-diskgroup RECO --ora-db-name orcl --ora-db-container false --instance-ip-addr 10.2.80.72 --instance-hostname marcos-db-rhel7-ajsy --allow-install-on-vm --no-patch  --nfs-backup-config vers=4 --nfs-backup-mount gmz-ansible-brew:/nfs/gcp 

time ./install-oracle.sh --ora-swlib-bucket gs://pythian-gto-oracle-software/19c --instance-ssh-user marcos --instance-ssh-key ~/.ssh/id_rsa --backup-dest "/mnt/nfs" --ora-swlib-path /u02/swlib/ --ora-version 19 --ora-swlib-type gcs --ora-asm-disks ~/asm_disk_config.json --ora-data-mounts ~/data_mounts_config.json --cluster-type NONE --ora-data-diskgroup DATA --ora-reco-diskgroup RECO --ora-db-name orcl --ora-db-container false --instance-ip-addr 10.2.80.102 --instance-hostname marcos-db-rhel8-zkcq --allow-install-on-vm --no-patch --nfs-backup-config vers=4 --nfs-backup-mount gmz-ansible-brew:/nfs/gcp 
```

## Expected Results:
Gist [output log](https://gist.github.com/gmarcospythian/2403365de7f62e2c2f786c9e7811d3ef) from full test run of toolkit on 19c and covering 4 versions of OS, rhel 7/8 oel 7/8. Tested using NFSv3 and NFSv4 options.
