### PR TITLE
Provision control-node for Ansible execution and update SSH key handling

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -53,12 +53,27 @@ To use this Terraform and Ansible integration, ensure you have the following too
 - **jq** - JSON processor required for handling playbook variables - [Installation Guide](https://stedolan.github.io/jq/download/)
 - **JMESPath** - [Installation Guide](https://pypi.org/project/jmespath/)
 
-Additionally, you will need:
+### 1. Service Account for the Control Node VM
 
-- A **Google Cloud project** with billing enabled
-- A **Service Account** with appropriate IAM roles for Compute Engine and Storage management
-- The following **IAM roles** added to the **Service Account** running **Terraform**:`roles/compute.instanceAdmin`, `roles/storage.objectAdmin`
-- A writeable [cloud storage bucket](https://cloud.google.com/storage/docs/creating-buckets) to store terraform state in
+Grant the service account attached to the control-node VM the following IAM roles:
+
+- `roles/compute.osAdminLogin`
+  Grants OS Login access with sudo privileges, required by the Ansible playbooks.
+- `roles/iam.serviceAccountUser` on the **target VM's service account**  
+  Allows the control-node to impersonate the target service account during SSH sessions.
+- `roles/storage.objectUser` on the **Terraform state Cloud Storage bucket**  
+  Permits the control-node to read and write the Terraform state.
+
+### 2. Firewall Rule for Internal IP Access
+Create a VPC firewall rule that allows ingress on TCP port 22 (or your custom SSH port) from the control-node VM to the target VM.  
+Since both VMs reside in the same VPC, a rule permitting traffic on port 22 between their subnets or network tags is sufficient.
+
+### 3. Terraform State Bucket
+Create a Cloud Storage bucket to store Terraform state files.  
+Assign the control-node service account read and write access to this bucket.
+
+### 4. OS Login is enabled
+OS Login must be enabled on all target VM instances. See [this guide](https://cloud.google.com/compute/docs/oslogin/set-up-oslogin) for instructions on how to enable OS Login.
 
 ---
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,4 +1,3 @@
 # Terraform
 
-See https://google.github.com/oracle-toolkit/terraform.md for documentation and
-example Terraform usage.
+See https://google.github.io/oracle-toolkit/terraform.html for documentation and example usage of Terraform to provision Oracle Database on Google Cloud.

--- a/terraform/main.tf.example
+++ b/terraform/main.tf.example
@@ -21,11 +21,12 @@ module "oracle_toolkit" {
   ## MANDATORY SETTINGS
   ##############################################################################
   # General settings
-  region                = "REGION"                # example: us-central1
-  zone                  = "ZONE"                  # example: us-central1-b
-  project_id            = "PROJECT_ID"            # example: my-project-123
-  subnetwork            = "SUBNET"                # example: default
-  service_account_email = "SERVICE_ACCOUNT_EMAIL" # example: 123456789-compute@developer.gserviceaccount.com
+  region                             = "REGION"                # example: us-central1
+  zone                               = "ZONE"                  # example: us-central1-b
+  project_id                         = "PROJECT_ID"            # example: my-project-123
+  subnetwork                         = "SUBNET"                # example: default
+  service_account_email              = "SERVICE_ACCOUNT_EMAIL" # example: oracle-vm-runner@my-project-123.iam.gserviceaccount.com
+  control_node_service_account_email = "SERVICE_ACCOUNT_EMAIL" # example: control-node-sa@my-project-123.iam.gserviceaccount.com
 
   # Instance settings
   instance_name        = "INSTANCE_NAME"  # example: oracle-rhel8-example

--- a/terraform/modules/oracle_toolkit_module/main.tf
+++ b/terraform/modules/oracle_toolkit_module/main.tf
@@ -44,47 +44,6 @@ locals {
   project_id = var.project_id
 }
 
-# Generate an SSH key pair
-resource "tls_private_key" "ssh_key" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
-# Store the private key in Secret Manager
-resource "google_secret_manager_secret" "ssh_private_key" {
-  secret_id = "ansible-ssh-private-key"
-  project   = local.project_id
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "ssh_private_key_version" {
-  secret      = google_secret_manager_secret.ssh_private_key.id
-  secret_data = tls_private_key.ssh_key.private_key_pem
-}
-
-# Store the public key in Secret Manager
-resource "google_secret_manager_secret" "ssh_public_key" {
-  secret_id = "ansible-ssh-public-key"
-  project   = local.project_id
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "ssh_public_key_version" {
-  secret      = google_secret_manager_secret.ssh_public_key.id
-  secret_data = tls_private_key.ssh_key.public_key_openssh
-}
-
-resource "local_file" "private_key" {
-  filename        = abspath("${path.module}/ansible-ssh-key")
-  content         = tls_private_key.ssh_key.private_key_pem
-  file_permission = "0600"
-}
-
-# Instance template module
 module "instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
   version = "~> 13.0"
@@ -109,7 +68,6 @@ module "instance_template" {
 
   metadata = {
     metadata_startup_script = var.metadata_startup_script
-    ssh-keys                = "ansible:${tls_private_key.ssh_key.public_key_openssh}"
   }
 
   additional_disks = local.additional_disks
@@ -117,7 +75,6 @@ module "instance_template" {
   tags = var.network_tags
 }
 
-# Compute instance module
 module "compute_instance" {
   source  = "terraform-google-modules/vm/google//modules/compute_instance"
   version = "~> 13.0"
@@ -138,52 +95,49 @@ module "compute_instance" {
   ]
 }
 
-# Local provisioner to run the Oracle Toolkit
-resource "null_resource" "oracle_toolkit" {
-  for_each = { for i, instance in module.compute_instance.instances_details : i => instance }
+resource "google_compute_instance" "control_node" {
+  project      = var.project_id
+  name         = var.control_node_name
+  machine_type = var.control_node_machine_type
+  zone         = var.zone
 
-  provisioner "remote-exec" {
-    inline = ["echo 'Running Ansible on ${each.value.network_interface[0].access_config[0].nat_ip}'"]
-
-    connection {
-      type        = "ssh"
-      user        = "ansible"
-      private_key = file(local_file.private_key.filename)
-      host        = each.value.network_interface[0].access_config[0].nat_ip
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      size  = 20
     }
   }
 
-  provisioner "local-exec" {
-    working_dir = "../"
-    command     = <<-EOT
-      bash install-oracle.sh \
-      --instance-ip-addr ${each.value.network_interface[0].access_config[0].nat_ip} \
-      --instance-ssh-user ansible \
-      --instance-ssh-key "${local_file.private_key.filename}" \
-      --ora-asm-disks-json '${jsonencode(local.asm_disk_config)}' \
-      --ora-data-mounts-json '${jsonencode(local.data_mounts_config)}' \
-      --swap-blk-device "/dev/disk/by-id/google-swap" \
-      --ora-swlib-bucket "${var.ora_swlib_bucket}" \
-      --ora-version "${var.ora_version}" \
-      --backup-dest "${var.ora_backup_dest}" \
-      ${var.ora_db_name != "" ? "--ora-db-name ${var.ora_db_name}" : ""} \
-      ${var.ora_db_container != "" ? "--ora-db-container ${lower(var.ora_db_container)}" : ""} \
-      ${var.ntp_pref != "" ? "--ntp-pref ${var.ntp_pref}" : ""} \
-      ${var.oracle_release != "" ? "--oracle-release ${var.oracle_release}" : ""} \
-      ${var.ora_edition != "" ? "--ora-edition ${var.ora_edition}" : ""} \
-      ${var.ora_listener_port != "" ? "--ora-listener-port ${var.ora_listener_port}" : ""} \
-      ${var.ora_redo_log_size != "" ? "--ora-redo-log-size ${var.ora_redo_log_size}" : ""} &
-    EOT
+  network_interface {
+    network       = var.subnetwork
+    access_config {
+      // Ephemeral public IP
+    }
   }
 
-  depends_on = [module.compute_instance, local_file.private_key]
-}
-
-# Deleting local private key after Oracle Toolkit provision
-resource "null_resource" "delete_privatekey" {
-  provisioner "local-exec" {
-    command = "rm -f ${local_file.private_key.filename}"
+  service_account {
+    email  = var.control_node_service_account_email
+    scopes = ["cloud-platform"]
   }
 
-  depends_on = [null_resource.oracle_toolkit]
+  metadata_startup_script = templatefile("${path.module}/scripts/setup.sh.tpl", {
+    instance_name       = module.compute_instance.instances_details[0].name
+    instance_zone       = module.compute_instance.instances_details[0].zone
+    ip_addr             = module.compute_instance.instances_details[0].network_interface[0].network_ip
+    asm_disk_config     = jsonencode(local.asm_disk_config)
+    data_mounts_config  = jsonencode(local.data_mounts_config)
+    swap_blk_device     = "/dev/disk/by-id/google-swap"
+    ora_swlib_bucket    = var.ora_swlib_bucket
+    ora_version         = var.ora_version
+    ora_backup_dest     = var.ora_backup_dest
+    ora_db_name         = var.ora_db_name
+    ora_db_container    = lower(var.ora_db_container)
+    ntp_pref            = var.ntp_pref
+    oracle_release      = var.oracle_release
+    ora_edition         = var.ora_edition
+    ora_listener_port   = var.ora_listener_port
+    ora_redo_log_size   = var.ora_redo_log_size
+  })
+
+  depends_on = [module.compute_instance]
 }

--- a/terraform/modules/oracle_toolkit_module/scripts/setup.sh.tpl
+++ b/terraform/modules/oracle_toolkit_module/scripts/setup.sh.tpl
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+apt-get install -y git ansible python3-jmespath
+
+ssh_user=$(gcloud compute os-login describe-profile --format=json | jq -r '.posixAccounts[].username')
+
+echo "Triggering SSH key creation via OS Login by running a one-time gcloud compute ssh command."
+echo "This ensures that a persistent SSH key pair is created and associated with your Google Account."
+echo "The private auto-generated ssh key (~/.ssh/google_compute_engine) will be used by Ansible to connect to the VM and run playbooks remotely."
+echo "Command:"
+echo "gcloud compute ssh ${instance_name} --zone=${instance_zone} --internal-ip --quiet --command whoami"
+
+until gcloud compute ssh ${instance_name} --zone=${instance_zone} --internal-ip --quiet --command whoami; do
+  echo "Waiting for SSH to become available on ${instance_name}..."
+  sleep 10
+done
+
+git clone https://github.com/google/oracle-toolkit.git
+
+cd oracle-toolkit
+
+bash install-oracle.sh \
+--instance-ip-addr ${ip_addr} \
+--instance-ssh-user $ssh_user \
+--instance-ssh-key /root/.ssh/google_compute_engine \
+--ora-asm-disks-json '${asm_disk_config}' \
+--ora-data-mounts-json '${data_mounts_config}' \
+--swap-blk-device ${swap_blk_device} \
+--ora-swlib-bucket ${ora_swlib_bucket} \
+--ora-version ${ora_version} \
+--backup-dest ${ora_backup_dest} \
+%{ if ora_db_name != "" }--ora-db-name ${ora_db_name} %{ endif } \
+%{ if ora_db_container != "" }--ora-db-container ${ora_db_container} %{ endif } \
+%{ if ntp_pref != "" }--ntp-pref ${ntp_pref} %{ endif } \
+%{ if oracle_release != "" }--oracle-release ${oracle_release} %{ endif } \
+%{ if ora_edition != "" }--ora-edition ${ora_edition} %{ endif } \
+%{ if ora_listener_port != "" }--ora-listener-port ${ora_listener_port} %{ endif } \
+%{ if ora_redo_log_size != "" }--ora-redo-log-size ${ora_redo_log_size} %{ endif }

--- a/terraform/modules/oracle_toolkit_module/variables.tf
+++ b/terraform/modules/oracle_toolkit_module/variables.tf
@@ -25,13 +25,25 @@ variable "fs_disks" {
 }
 
 variable "instance_name" {
-  description = "The name for the VM instance."
+  description = "The name for the target VM instance."
   type        = string
+}
+
+variable "control_node_name" {
+  description = "The name for the control node VM."
+  type        = string
+  default     = "control-node"
 }
 
 variable "machine_type" {
   description = "The machine type to be used for the instance (e.g., n4-standard-2)."
   type        = string
+}
+
+variable "control_node_machine_type" {
+  description = "The machine type to be used for the instance (e.g., n2-standard-2)."
+  type        = string
+  default     = "e2-medium"
 }
 
 variable "metadata_startup_script" {
@@ -169,6 +181,11 @@ variable "region" {
 
 variable "service_account_email" {
   description = "The service account email used for managing compute instance permissions."
+  type        = string
+}
+
+variable "control_node_service_account_email" {
+  description = "The service account used by the control node."
   type        = string
 }
 


### PR DESCRIPTION
This change provisions a new GCE instance (control-node) where Ansible playbooks are executed via a startup script. 

Key changes:

1. Updated the Terraform module to provision the control-node VM that runs Ansible playbooks via a startup script. 
2. The control-node runs a startup script that prepares the environment and executes install-oracle.sh.
    As part of the setup, it runs a one-time gcloud compute ssh command to:

    - Trigger OS Login-managed SSH key creation
    - Store the public key in the user’s Google Account
    - Store the private key locally at ~/.ssh/google_compute_engine, which Ansible uses to connect to target VMs
3. Deleted code from main.tf that generated SSH key pairs and stored them in Secret Manager. This is no longer needed since Ansible now uses the SSH keys created by the "gcloud compute ssh" command.
4. Fixed the link in terraform/README.md to point to the correct Terraform usage guide.

[Link to the log from successful run of install-oracle.sh](https://gist.github.com/AlexBasinov/f915fff06a94521951ecd8905a14e3cd)