### PR TITLE
Add support for APR2025 RUs and Free Edition 23.8; Documenation fixes

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -71,9 +71,9 @@ additional details and comprehensive explanations of the toolkit, scripting,
 options, and usage scenarios. All commands run from the "control node".
 
 > **NOTE:** If deploying a single-instance database on GCE, refer to the
-[Quickstart for Using the Oracle Toolkit for Google Cloud on Compute Engine VMs](compute-vm-quickstart.md)
-document for additional information on provisioning GCE infrastructure and
-getting started with this toolkit.
+> [Quickstart for Using the Oracle Toolkit for Google Cloud on Compute Engine VMs](compute-vm-quickstart.md)
+> document for additional information on provisioning GCE infrastructure and
+> getting started with this toolkit.
 
 1. Validate media specifying GCS storage bucket and optionally database:
 
@@ -481,6 +481,12 @@ Support")</th>
 </tr>
 <tr>
 <td></td>
+<td></td>
+<td>Database Release Update 21.18.0.0.0</td>
+<td>p37655430_210000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
 <td>Oracle Grid Infrastructure 21.3.0.0.0 for Linux x86-64</td>
 <td>V1011504-01.zip</td>
 </tr>
@@ -547,8 +553,14 @@ Support")</th>
 <tr>
 <td></td>
 <td></td>
+<td>GI Release Update 21.18.0.0.0</td>
+<td>p37642955_210000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td></td>
 <td>OPatch Utility</td>
-<td><a href="https://updates.oracle.com/download/6880880.html"> p6880880_122010_Linux-x86-64.zip</a></td>
+<td><a href="https://updates.oracle.com/download/6880880.html"> p6880880_210000_Linux-x86-64.zip</a></td>
 </tr>
 <tr>
 <td>19.3.0.0.0</td>
@@ -565,7 +577,13 @@ Support")</th>
 <tr>
 <td></td>
 <td>Patch - MOS</TD>
-<TD>COMBO OF OJVM RU COMPONENT 19.26.0.0.250100 + GI RU 19.26.0.0.250100</td>
+<TD>COMBO OF OJVM RU COMPONENT 19.27.0.0.250415 + GI RU 19.27.0.0.250415</td>
+<td>p37591516_190000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</TD>
+<TD>COMBO OF OJVM RU COMPONENT 19.26.0.0.250121 + GI RU 19.26.0.0.250121</td>
 <td>p37262208_190000_Linux-x86-64.zip</td>
 </tr>
 <tr>
@@ -1339,11 +1357,9 @@ After installation is complete, you can adjust any of the attributes of the
 backup scheme. You can also replace any and all parts of the initial backup
 scheme or the backup script with your own scripts or backup tools.
 
-#### gcsfuse backup 
+#### gcsfuse backup
 
-You can use Cloud Storage buckets for Oracle rman scripts to write and store backups. 
-
-
+You can use Cloud Storage buckets for Oracle rman scripts to write and store backups.
 
 #### Cloud Storage bucket
 
@@ -1353,7 +1369,6 @@ You can use Cloud Storage buckets for Oracle rman scripts to write and store bac
   Cloud Storage buckets as file systems on Linux or macOS systems.
 - Review backup [Cloud Storage bucket options](https://cloud.google.com/storage).
 
-  
 To use a Cloud Storage bucket for your backups, you need to follow the steps below:
 
 - Identify the Compute Engine instance service account. Go to:
@@ -1364,15 +1379,14 @@ To use a Cloud Storage bucket for your backups, you need to follow the steps bel
   - Select the bucket that will store the backups, click on the three dots on the far right of the bucket selected and click Edit access.
   - Click on Add Principal and add the identified Compute Engine VM instance service account from the Oracle Server to configure.
   - In the Role drop down select Storage Legacy Bucket Owner and save.
-  
+
 #### Cloud Storage FUSE
 
-- With Cloud Storage FUSE, you can use the auth service account of the  Compute Engine instance to access and mount the Cloud Storage bucket. 
+- With Cloud Storage FUSE, you can use the auth service account of the Compute Engine instance to access and mount the Cloud Storage bucket.
 - Follow the steps above on Cloud Storage bucket.
 - You can verify the auth service account by running the command as the Example below:
-  - ```gcloud compute ssh gce_vm_instance_name --command="sudo su -c 'gcloud auth list'"```
-  - You should see the same account in the auth list as the one used in the  Cloud Storage bucket configuration steps. 
-
+  - `gcloud compute ssh gce_vm_instance_name --command="sudo su -c 'gcloud auth list'"`
+  - You should see the same account in the auth list as the one used in the Cloud Storage bucket configuration steps.
 
 ### Parameters
 
@@ -1904,8 +1918,6 @@ on the CLI instead of the CLUSTER_CONFIG file.
 </tbody>
 </table>
 
-
-
 #### Backup configuration parameters
 
 <table>
@@ -2090,8 +2102,6 @@ requirements for this directory is minimal.</td>
 </tr>
 </tbody>
 </table>
-
-
 
 #### Additional operational parameters
 
@@ -2468,14 +2478,15 @@ Oracle has released serveral versions of free edition, often **without chaning t
 
 Specific supported versions of Oracle Database 23 free edition currently includes:
 
-| Product | Specific Version | Software RPM Filename                            | Preinstall RPM Filename                                |
-| :-----: | :--------------: | :----------------------------------------------- | :----------------------------------------------------- |
-|  23ai   |   23.7.0.25.01   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|  23ai   |   23.6.0.24.10   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|  23ai   |   23.5.0.24.07   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|  23ai   |   23.4.0.24.05   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
-|   23c   |   23.3.0.23.09   | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
-|   23c   |    23.2.0.0.0    | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
+| Product | Specific Version | Software RPM Filename                             | Preinstall RPM Filename                                |
+| :-----: | :--------------: | :------------------------------------------------ | :----------------------------------------------------- |
+|  23ai   |   23.8.0.25.04   | `oracle-database-free-23ai-23.8-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.7.0.25.01   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.6.0.24.10   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.5.0.24.07   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|  23ai   |   23.4.0.24.05   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
+|   23c   |   23.3.0.23.09   | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`   | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
+|   23c   |    23.2.0.0.0    | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`   | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 
 Even though the file names may be the same while the version changes, the RPMs for the various versions can still be staged in the software library. Possibly by manually changing the file names for uniqueness (and then updating the `rdbms_software` variable in the [roles/common/defaults/main.yml](../roles/common/defaults/main.yml) file accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders**.
 
@@ -2513,6 +2524,7 @@ ORA_VERSION
 --ora-version
 </pre></p></td>
 <td>
+23.8.0.25.04<br>
 23.7.0.25.01<br>
 23.6.0.24.10<br>
 23.5.0.24.07<br>
@@ -2789,7 +2801,7 @@ ok: [db-23ai-free]
 
 ### Validate the Oracle installation with ORAchk
 
-The orachk utility can be used to validate the Oracle installation. 
+The orachk utility can be used to validate the Oracle installation.
 
 ORAchk will check for known problems with the Oracle installation and configuration, and provide recommendations for resolving any issues that are found.
 
@@ -2797,9 +2809,9 @@ To run ORAchk, download the AHF utility from the Oracle support site.
 
 The following Oracle Support Note will provide the download link:
 
-  `Autonomous Health Framework (AHF) - Including Trace File Analyzer and Orachk/Exachk (Doc ID 2550798.1)`
+`Autonomous Health Framework (AHF) - Including Trace File Analyzer and Orachk/Exachk (Doc ID 2550798.1)`
 
-ORAchk is a part of the AHF utility.  It is not necessary to install the entire AHF utility to run ORAchk.
+ORAchk is a part of the AHF utility. It is not necessary to install the entire AHF utility to run ORAchk.
 
 The `check-oracle.sh` script provided with the toolkit will allow you to install, run and uninstall ORAchk on the target server.
 
@@ -2911,6 +2923,7 @@ Use the the `check-oracle.sh` script to install ORAchk.
    --ahf-location gs://oracle-software/AHF/AHF-LINUX_v25.1.0.zip
 
 ```
+
 example output:
 Note: skipped steps are omitted
 
@@ -2929,6 +2942,7 @@ PLAY RECAP *********************************************************************
 ora-db-server-19c   : ok=7    changed=2    unreachable=0    failed=0    skipped=8    rescued=0    ignored=0
 
 ```
+
 #### Running ORAchk
 
 ```bash
@@ -2962,7 +2976,6 @@ ora-db-server-19c   : ok=6    changed=3    unreachable=0    failed=0    skipped=
 ```
 
 As shown in the message, the orachk zip file is saved locally at `/tmp/orachk_ora-db-server-19c_ORCL_020525_193642.zip`.
-
 
 ```text
 $ unzip -l /tmp/orachk_ora-db-server-19c_ORCL_020525_193642.zip | head -12

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -170,6 +170,19 @@ gi_software:
       - "BM7zeZHbGPgZD31KGbJpEg=="
 
 rdbms_software:
+  - name: 23ai_free_23_8
+    version: 23.8.0.25.04
+    edition: FREE
+    files:
+      - "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm"
+      - "oracle-database-free-23ai-23.8-1.el8.x86_64.rpm"
+    sha256sum:
+      - "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b"
+      - "cd0d16939150e6ec5e70999a762a13687bfa99b05c4f310593e7ca3892e1d0ce"
+    md5sum:
+      - "TmjqUT878Owv7NbXGECpTA=="
+      - "hkL/hxeYbB7z5lz+3r3kww=="
+
   - name: 23ai_free_23_7
     version: 23.7.0.25.01
     edition: FREE
@@ -331,7 +344,7 @@ opatch_patches:
   - { category: "OPatch", release: "12.2.0.1.0", patchnum: "6880880", patchfile: "p6880880_122010_Linux-x86-64.zip", md5sum: "" }
   - { category: "OPatch", release: "18.0.0.0.0", patchnum: "6880880", patchfile: "p6880880_180000_Linux-x86-64.zip", md5sum: "" }
   - { category: "OPatch", release: "19.3.0.0.0", patchnum: "6880880", patchfile: "p6880880_190000_Linux-x86-64.zip", md5sum: "" }
-  - { category: "OPatch", release: "21.3.0.0.0", patchnum: "6880880", patchfile: "p6880880_122010_Linux-x86-64.zip", md5sum: "" }
+  - { category: "OPatch", release: "21.3.0.0.0", patchnum: "6880880", patchfile: "p6880880_210000_Linux-x86-64.zip", md5sum: "" }
 
 gi_interim_patches:
   - category: "HAS_interim_patch"
@@ -427,6 +440,7 @@ gi_patches:
   - { category: "RU", base: "19.3.0.0.0", release: "19.24.0.0.240716", patchnum: "36522439", patchfile: "p36522439_190000_Linux-x86-64.zip", patch_subdir: "/36582629", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "ysQplJ/kY19rRPZmntFsMA==" }
   - { category: "RU", base: "19.3.0.0.0", release: "19.25.0.0.241015", patchnum: "36866740", patchfile: "p36866740_190000_Linux-x86-64.zip", patch_subdir: "/36916690", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "f8DKaIiP7v811/WaRyacTQ==" }
   - { category: "RU", base: "19.3.0.0.0", release: "19.26.0.0.250121", patchnum: "37262208", patchfile: "p37262208_190000_Linux-x86-64.zip", patch_subdir: "/37257886", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "zqZeJ3/ujDWcLr+reZOHpw==" }
+  - { category: "RU", base: "19.3.0.0.0", release: "19.27.0.0.250415", patchnum: "37591516", patchfile: "p37591516_190000_Linux-x86-64.zip", patch_subdir: "/37641958", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "kkyZC9RP8eolBgdu9Y3q7g==" }
 
 # 21c GRID RU - 21.4 and 21.7 are available only via SR
 #     RDBMS RU - 21.4 - 21.7 are available only via SR
@@ -443,6 +457,7 @@ gi_patches:
   - { category: "RU", base: "21.3.0.0.0", release: "21.15.0.0.0", patchnum: "36696109", patchfile: "p36696109_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "9aPx+eWkCSEVS9vKqoVi/Q==" }
   - { category: "RU", base: "21.3.0.0.0", release: "21.16.0.0.0", patchnum: "36990664", patchfile: "p36990664_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "N1p/HLEg+UFYAr04loujqg==" }
   - { category: "RU", base: "21.3.0.0.0", release: "21.17.0.0.0", patchnum: "37349593", patchfile: "p37349593_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "Mt0Bw+IPKqoKh31YkneCrg==" }
+  - { category: "RU", base: "21.3.0.0.0", release: "21.18.0.0.0", patchnum: "37642955", patchfile: "p37642955_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatchauto apply", ocm: false, upgrade: false, md5sum: "b8YrXNXis6agqIHny746Xw==" }
 
 rdbms_patches:
 # 11.2.0.4 OJVM packages from Combo
@@ -511,6 +526,7 @@ rdbms_patches:
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.24.0.0.240716", patchnum: "36522439", patchfile: "p36522439_190000_Linux-x86-64.zip", patch_subdir: "/36414915", prereq_check: true, method: "opatch apply", ocm: false, upgrade: true, md5sum: "ysQplJ/kY19rRPZmntFsMA==" }
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.25.0.0.241015", patchnum: "36866740", patchfile: "p36866740_190000_Linux-x86-64.zip", patch_subdir: "/36878697", prereq_check: true, method: "opatch apply", ocm: false, upgrade: true, md5sum: "f8DKaIiP7v811/WaRyacTQ==" }
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.26.0.0.250121", patchnum: "37262208", patchfile: "p37262208_190000_Linux-x86-64.zip", patch_subdir: "/37102264", prereq_check: true, method: "opatch apply", ocm: false, upgrade: true, md5sum: "zqZeJ3/ujDWcLr+reZOHpw==" }
+  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.27.0.0.250415", patchnum: "37591516", patchfile: "p37591516_190000_Linux-x86-64.zip", patch_subdir: "/37499406", prereq_check: true, method: "opatch apply", ocm: false, upgrade: true, md5sum: "kkyZC9RP8eolBgdu9Y3q7g==" }
 # 21c RDBMS RU - 21.4 - 21.7 are available only via SR
   - { category: "RU", base: "21.3.0.0.0", release: "21.8.0.0.0", patchnum: "34527084", patchfile: "p34527084_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatch apply", ocm: false, upgrade: false, md5sum: "niyd8DhbfJzZb67v98ElWA==" }
   - { category: "RU", base: "21.3.0.0.0", release: "21.9.0.0.0", patchnum: "34839741", patchfile: "p34839741_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatch apply", ocm: false, upgrade: false, md5sum: "VaJNd/YSjzbH4orQjBIt8g==" }
@@ -522,3 +538,4 @@ rdbms_patches:
   - { category: "RU", base: "21.3.0.0.0", release: "21.15.0.0.0", patchnum: "36696242", patchfile: "p36696242_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatch apply", ocm: false, upgrade: false, md5sum: "BfnTadblbMTHccGi7ZQaXw==" }
   - { category: "RU", base: "21.3.0.0.0", release: "21.16.0.0.0", patchnum: "36991631", patchfile: "p36991631_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatch apply", ocm: false, upgrade: false, md5sum: "qcuTf7+EzsEGvMdCXRKZlQ==" }
   - { category: "RU", base: "21.3.0.0.0", release: "21.17.0.0.0", patchnum: "37350281", patchfile: "p37350281_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatch apply", ocm: false, upgrade: false, md5sum: "dQjBqlXWOumEZU3QAJzD9Q==" }
+  - { category: "RU", base: "21.3.0.0.0", release: "21.18.0.0.0", patchnum: "37655430", patchfile: "p37655430_210000_Linux-x86-64.zip", patch_subdir: "/", prereq_check: false, method: "opatch apply", ocm: false, upgrade: false, md5sum: "4JhJvWSOeDMYUIupR0jFZA==" }


### PR DESCRIPTION
## Change Description:

Add support for the latest RU patches (up to APR2025). And also add support for installing the latest Oracle Database 23ai Free Edition: version `23.8.0.25.04`.

## Solution Overview:

Updated the `roles/common/defaults/main.yml` file to support the APR2025 RUs for versions **19.27** and **21.18**. Also added support for Free Edition **23.8** where, for the first time, Oracle is now including the database version in the RPM file name.

The RU updates will require that the following files are staged in the software library:

```
p37591516_190000_Linux-x86-64.zip
p37642955_210000_Linux-x86-64.zip
p37655430_210000_Linux-x86-64.zip
```

Further, the latest versions of OPatch must be added to the software library:

```
p6880880_190000_Linux-x86-64.zip
p6880880_210000_Linux-x86-64.zip
```

And for Free Edition installations, the new RPM:

```
oracle-database-free-23ai-23.8-1.el8.x86_64.rpm
```

In addition, this change includes minor documentation clean-up changes including:

- Fixed bad link for 21c OPatch download.
- Minor documentation formatting fixes.

## Test Commands:

### Test Prep:

### Test 1: Apply new 19.27 patch:

Enter the appropriate IP address for the target database server that will be patched to `19.27`:

```bash
export INSTANCE_IP_ADDR=10.2.80.64
```

Apply the `19.27` patch set to both the GI and RDBMS homes:

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname db-server19c \
  --ora-edition EE \
  --ora-version 19.3.0.0.0 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --backup-dest "+RECO" \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]' \
  --no-patch

./apply-patch.sh \
  --inventory-file inventory_files/inventory_db-server19c_ORCL \
  --ora-version 19 \
  --ora-release 19.27.0.0.250415 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --ora-swlib-path /u02/oracle_install \
  --ora-staging /u02/oracle_install
```

### Test 2: Apply new 21.18 patch:

Enter the appropriate IP address for the target database server that will be patched to `21.18`:

```bash
export INSTANCE_IP_ADDR=10.2.80.65
```

Apply the `21.18` patch set to both the GI and RDBMS homes:

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname db-server21c \
  --ora-edition EE \
  --ora-version 21.3.0.0.0 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --backup-dest "+RECO" \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"RECO1"}]}]' \
  --no-patch

./apply-patch.sh \
  --inventory-file inventory_files/inventory_db-server21c_ORCL \
  --ora-version 21 \
  --ora-release 21.18.0.0.0 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --ora-swlib-path /u02/oracle_install \
  --ora-staging /u02/oracle_install
```

### Test 3: Run a complete 23ai Free Edition install:

Install the "latest" version of 23ai Free Edition by default (i.e. by not explicitly stating a specific version):

```bash
export INSTANCE_IP_ADDR=10.2.80.68

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition free \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

ssh -t ${INSTANCE_IP_ADDR} <<EOF 2>/dev/null
sudo -i -u oracle sqlplus -s / as sysdba <<'SQL'
select version_full from v\$instance;
exit
SQL
EOF

./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.8.0.25.04 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --yes-i-am-sure
```

### Test 4: Run a custom version of 23ai Free Edition full installation:

Install a specific (older) version of 23ai Free Edition by including the `--ora-version` argument and an older version as the value:

```bash
export INSTANCE_IP_ADDR=10.2.80.68

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-version 23.7.0.25.01 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

ssh -t ${INSTANCE_IP_ADDR} <<EOF 2>/dev/null
sudo -i -u oracle sqlplus -s / as sysdba <<'SQL'
select version_full from v\$instance;
exit
SQL
EOF

./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.7.0.25.01 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --yes-i-am-sure
```

### Test 5: Run a custom version of 23ai Free Edition full installation using a short version value:

Default to the most recent version of 23ai Free Edition if the `--ora-version 23` argument is included:

```bash
export INSTANCE_IP_ADDR=10.2.80.68

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-version 23 \
  --ora-swlib-bucket gs://BUCKET_NAME \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

ssh -t ${INSTANCE_IP_ADDR} <<EOF 2>/dev/null
sudo -i -u oracle sqlplus -s / as sysdba <<'SQL'
select version_full from v\$instance;
exit
SQL
EOF

./cleanup-oracle.sh \
  --ora-edition FREE \
  --ora-version 23.8.0.25.04 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --yes-i-am-sure
```

## Patching Verification Steps:

Check that the RDBMS Oracle Home has been properly patched. As the `oracle` user run:

```bash
${ORACLE_HOME}/OPatch/opatch lsinventory -patch | grep -i 'Release Update'
```

Verify that the database is patched to the correct release. Verification command:

```bash
sqlplus -s -L / as sysdba <<EOF
COL VERSION FORMAT A20
COL ACTION_TIME FORMAT A40
SELECT patch_type, TRIM(REGEXP_SUBSTR(description,' \d{2}\.([^\s]+) ')) version, action_time
  FROM dba_registry_sqlpatch s
 WHERE patch_type IN ('RU','RUI','RUR','CU') AND  status = 'SUCCESS'
 ORDER BY action_time DESC;
EOF
```

Check that the Grid Infrastructure Home has been properly patched. As the `grid` user run:

```bash
${GRID_HOME}/OPatch/opatch lsinventory -patch | grep -i 'Release Update'
```

As a small bonus verification, check the version of the `asmcmd` utility and ensure that it matches the patch version:

```bash
asmcmd -V
```

## Results:

- [Full 19c test run output including patching](https://gist.github.com/simonpane/293400e9448f312a6a6c477e278bf66f)
- [Verification of patched RDBMS and GI software from 19c database server](https://gist.github.com/simonpane/ab888f704f40a0106f41854e06d08c75)
- [Full 21c test run output including patching](https://gist.github.com/simonpane/dbd401fc4690cc10aee588e50dc714ed)
- [Verification of patched RDBMS and GI software from 21c database server](https://gist.github.com/simonpane/e1fc4857f53940258b12ac55fed9eab9)
- [Free Edition test using the "latest" version](https://gist.github.com/simonpane/eda1539696ee95a244487a2a3f832547)
- [Free Edition test using an explicitly specified custom/older version](https://gist.github.com/simonpane/396d8e69ef0d815746c506581fa4c7e4)
- [Free Edition test using the short version argument](https://gist.github.com/simonpane/9da902ff2dac03f6b903a9b9aeb32f83)
