### PR TITLE
Update required version and add random provider

### DIFF
--- a/terraform/modules/oracle_toolkit_module/versions.tf
+++ b/terraform/modules/oracle_toolkit_module/versions.tf
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.10.5"
+  required_version = ">= 1.5.7"
   required_providers {
     google = {
       source  = "hashicorp/google"
       version = "~> 6.20.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7.2"
     }
   }
 }


### PR DESCRIPTION
This PR adds the random provider to the required_providers block and updates the Terraform required_version to 1.5.7 which is the latest version [supported by Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/terraform#terraform_versions).