### PR TITLE
Make assign_public_ip variable work correctly for database VM

### DIFF
--- a/terraform/modules/oracle_toolkit_module/main.tf
+++ b/terraform/modules/oracle_toolkit_module/main.tf
@@ -87,12 +87,10 @@ module "compute_instance" {
   instance_template   = module.instance_template.self_link
   deletion_protection = false
 
-  access_config = [
-    {
-      nat_ip       = null
-      network_tier = "PREMIUM"
-    }
-  ]
+  access_config = var.assign_public_ip ? [{
+    nat_ip       = null
+    network_tier = "PREMIUM"
+  }] : []
 }
 
 resource "random_id" "suffix" {


### PR DESCRIPTION
Added conditional logic to the access_config block to respect the assign_public_ip variable. When set to false, no public IP will be assigned to the database VM.