### PR TITLE
Enable OS Login at the instance level

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -87,10 +87,6 @@ Upload the ZIP file to your GCS bucket:
 ```bash
 gsutil cp /tmp/oracle-toolkit.zip gs://your-bucket-name/
 ```
-
-### 5. OS Login is enabled
-OS Login must be enabled on all target VM instances. See [this guide](https://cloud.google.com/compute/docs/oslogin/set-up-oslogin) for instructions on how to enable OS Login.
-
 ---
 
 ## Project Directory Structure

--- a/terraform/modules/oracle_toolkit_module/main.tf
+++ b/terraform/modules/oracle_toolkit_module/main.tf
@@ -68,6 +68,7 @@ module "instance_template" {
 
   metadata = {
     metadata_startup_script = var.metadata_startup_script
+    enable-oslogin          = "TRUE"
   }
 
   additional_disks = local.additional_disks


### PR DESCRIPTION
Enable OS Login at the instance level to avoid requiring project-wide changes. 