### PR TITLE
Add support for --ora-release in install-oracle.sh

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1517,6 +1517,17 @@ ORA_VERSION
 <td>All mainstream major releases.</td>
 </tr>
 <tr>
+<td>Oracle software release (patch level)</td>
+<td><p><pre>
+ORA_RELEASE
+--ora-release
+</pre></p>
+</td>
+<td>A fully-qualified release number, such as 19.7.0.0.200414<br>
+Default: latest</td>
+<td>Oracle patch level to apply as part of installation.</td>
+</tr>
+<tr>
 <td>Oracle edition</td>
 <td><p><pre>
 ORA_EDITION

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -257,7 +257,7 @@ COMPATIBLE_RDBMS_PARAM="^[0-9][0-9]\.[0-9].*"
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 ###
 GETOPT_MANDATORY="ora-swlib-bucket:"
-GETOPT_OPTIONAL="gcs-backup-config:,gcs-backup-bucket:,gcs-backup-temp-path:,nfs-backup-config:,nfs-backup-mount:,backup-dest:,ora-version:,no-patch,ora-edition:,cluster-type:,cluster-config:,cluster-config-json:"
+GETOPT_OPTIONAL="gcs-backup-config:,gcs-backup-bucket:,gcs-backup-temp-path:,nfs-backup-config:,nfs-backup-mount:,backup-dest:,ora-version:,ora-release:,no-patch,ora-edition:,cluster-type:,cluster-config:,cluster-config-json:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-staging:,ora-db-name:,ora-db-domain:,ora-db-charset:,ora-disk-mgmt:,ora-role-separation:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-data-destination:,ora-data-diskgroup:,ora-reco-destination:,ora-reco-diskgroup:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-asm-disks:,ora-asm-disks-json:,ora-data-mounts:,ora-data-mounts-json:,ora-listener-port:,ora-listener-name:"
@@ -293,6 +293,10 @@ while true; do
     if [[ "${ORA_VERSION}" = "12.2" ]] ; then ORA_VERSION="12.2.0.1.0"; fi
     if [[ "${ORA_VERSION}" = "12.1" ]] ; then ORA_VERSION="12.1.0.2.0"; fi
     if [[ "${ORA_VERSION}" = "11" ]]   ; then ORA_VERSION="11.2.0.4.0"; fi
+    shift
+    ;;
+  --ora-release)
+    ORA_RELEASE="$2"
     shift
     ;;
   --no-patch)
@@ -579,6 +583,10 @@ shopt -s nocasematch
 
 [[ ! "$ORA_VERSION" =~ $ORA_VERSION_PARAM ]] && {
   echo "Incorrect parameter provided for ora-version: $ORA_VERSION"
+  exit 1
+}
+[[ ! "$ORA_RELEASE" =~ $ORA_RELEASE_PARAM ]] && {
+  echo "Incorrect parameter provided for ora-release: $ORA_RELEASE"
   exit 1
 }
 [[ ! "$ORA_EDITION" =~ $ORA_EDITION_PARAM ]] && {

--- a/terraform/main.tf.example
+++ b/terraform/main.tf.example
@@ -91,9 +91,9 @@ module "oracle_toolkit" {
   ora_db_name       = ""            # example: "test"
   ora_db_container  = false         # example: false
   ntp_pref          = ""            # example: "169.254.169.254"
-  oracle_release    = ""            # example: "19.7.0.0.200414"
+  ora_release       = ""            # example: "19.7.0.0.200414"
   ora_edition       = ""            # example: "EE"
-  ora_listener_port = ""            # example: 1521 
+  ora_listener_port = ""            # example: 1521
   ora_redo_log_size = ""            # example: "100MB"
 
   ##############################################################################

--- a/terraform/modules/oracle_toolkit_module/main.tf
+++ b/terraform/modules/oracle_toolkit_module/main.tf
@@ -145,7 +145,7 @@ resource "google_compute_instance" "control_node" {
     ora_db_name         = var.ora_db_name
     ora_db_container    = lower(var.ora_db_container)
     ntp_pref            = var.ntp_pref
-    oracle_release      = var.oracle_release
+    ora_release         = var.ora_release
     ora_edition         = var.ora_edition
     ora_listener_port   = var.ora_listener_port
     ora_redo_log_size   = var.ora_redo_log_size

--- a/terraform/modules/oracle_toolkit_module/scripts/setup.sh.tpl
+++ b/terraform/modules/oracle_toolkit_module/scripts/setup.sh.tpl
@@ -67,7 +67,7 @@ bash install-oracle.sh \
 %{ if ora_db_name != "" }--ora-db-name "${ora_db_name}" %{ endif } \
 %{ if ora_db_container != "" }--ora-db-container "${ora_db_container}" %{ endif } \
 %{ if ntp_pref != "" }--ntp-pref "${ntp_pref}" %{ endif } \
-%{ if oracle_release != "" }--oracle-release "${oracle_release}" %{ endif } \
+%{ if ora_release != "" }--ora-release "${ora_release}" %{ endif } \
 %{ if ora_edition != "" }--ora-edition "${ora_edition}" %{ endif } \
 %{ if ora_listener_port != "" }--ora-listener-port "${ora_listener_port}" %{ endif } \
 %{ if ora_redo_log_size != "" }--ora-redo-log-size "${ora_redo_log_size}" %{ endif }

--- a/terraform/modules/oracle_toolkit_module/variables.tf
+++ b/terraform/modules/oracle_toolkit_module/variables.tf
@@ -148,12 +148,12 @@ variable "ora_version" {
   }
 }
 
-variable "oracle_release" {
+variable "ora_release" {
   type        = string
   default     = "latest"
   description = "Oracle release update version (patchlevel)."
   validation {
-    condition     = var.oracle_release == "" || var.oracle_release == "latest" || can(regex("^\\d+(\\.\\d+)*$", var.oracle_release))
+    condition     = var.ora_release == "" || var.ora_release == "latest" || can(regex("^\\d+(\\.\\d+)*$", var.ora_release))
     error_message = "Invalid Oracle release version. It should be in the format '19.10', '21.3.0.0', etc."
   }
 }


### PR DESCRIPTION
## The problem

`--ora-release` is used internally in the toolkit (and in apply-patch.sh), but isn't formally taken as a parameter, so there's no way to a user to specify a specific release to update to as part of `install-oracle.sh`;  thye'd need to install a base release and patch up.  

Secondarily, the terraform code accepts an `oracle-release` parameter, which doesn't actually exist

## The fix

Add support for an `--ora-release` parameter in `install-oracle.sh`, including parameter checking, and documentation.

In terraform code, rename `--oracle-release` to `--ora-release` to take advantage of this parameter.

## Testcase

* Package up this branch into a zip file on a GCS bucket
    zip -r /tmp/infra-manager.zip . -x ".git*" -x "terraform/.terraform*" -x "*.tfvars"
    gcloud storage cp /tmp/infra-manager.zip "${toolkit_bucket}"
* Set up a `main.tf` including
      ora_release    = "19.3.1.0.0"            # example: "19.7.0.0.200414"
* Launching a terraform run
```
terraform init
terraform plan
terraform apply
```

## Output

terraform output: https://gist.github.com/mfielding/d229e8ff1ff84a5c0069be334144204c
startup-script output (including ansible): https://gist.github.com/mfielding/822226c114abdfc856c0644813186081
