### PR TITLE
Update calculations of `kernel.shmmax` and `kernel.shmall`

### DIFF
--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -130,7 +130,9 @@ sysctl_param_values:
   - parameter: "kernel.sem"
     value: "250 32000 100 128"
   - parameter: "kernel.shmmax"
-    value: "{{ ((ansible_memtotal_mb + 1) * 524288) | round(0, 'ceil') | int }}"  # (MB->Bytes)/2: 1024*1024/2 = 524288
+    value: "{{ (ansible_memtotal_mb * 1048576 * 0.9) | round(0, 'ceil') | int }}"  # 90% of physical memory in bytes
+  - parameter: "kernel.shmall"
+    value: "{{ (((ansible_memtotal_mb * 1048576 * 0.9) | round(0, 'ceil')) / ansible_facts.ansible_system_capabilities.page_size | default(4096)) | round(0, 'ceil') | int }}"  # 90% of physical memory in pages
   - parameter: "kernel.shmmni"
     value: 4096
   - parameter: "kernel.panic_on_oops"

--- a/roles/ora-host/tasks/kernel_parameters.yml
+++ b/roles/ora-host/tasks/kernel_parameters.yml
@@ -31,19 +31,6 @@
         sysctl_out.stdout_lines | map('regex_replace', '^(\S*)\s*=\s*(\S+.*)$', '{ "parameter": "\1", "value": "\2" }') | map('from_json') | list
       }}
 
-- name: kernel_parameters | Update the shmall sysctl value (if less than "ram_pct_used" the size of physical memory)
-  sysctl:
-    name: "kernel.shmall"
-    value: "{{ ((ansible_memtotal_mb + 1) * 256 * (ram_pct_used | int) / 100) | round(0, 'ceil') | int }}"  # (MB->bytes)/pagesize: 1024*1024/4096=256
-    state: present
-    sysctl_set: true
-    reload: true
-    ignoreerrors: true
-  vars:
-    current_shmall: "{{ (sysctl_settings | selectattr('parameter', 'equalto', 'kernel.shmall') | map(attribute='value') | first) | default('0') }}"
-    calculated_shmall: "{{ ((ansible_memtotal_mb + 1) * 256 * (ram_pct_used | int) / 100) | round(0, 'ceil') }}"
-  when: current_shmall | int < calculated_shmall | int or current_shmall | int > ((ansible_memtotal_mb + 1 ) * 256)  # Must cast to int at this stage for Ansible 2.9
-
 - name: kernel_parameters | Update other sysctl values
   sysctl:
     name: "{{ item.parameter }}"


### PR DESCRIPTION
## Change Description:

Adjust kernel memory parameters `kernel.shmmax` and `kernel.shmall` to avoid database instance startup issues on some machine shapes or with certain SGA sizes.

Possible error from DBCA:

```
[WARNING] ORA-27125: unable to create shared memory segment
```

## Solution Overview:

Oracle documentation (reference: https://docs.oracle.com/en/database/oracle/oracle-database/23/ladbi/minimum-parameter-settings-for-installation.html) suggests aggressive values for these kernel memory parameters and the toolkit currently aligns with these guidelines.

However, these guidelines are not in alignment with what Oracle does in practice through the use of the preinstallation scripts. (Details on kernel parameter calculation guidelines, and results from the Oracle provided preinstall scripts are provided in detail in previous ticket: https://github.com/google/oracle-toolkit/pull/199 .) In the preinstallation scripts Oracle sets these kernel settings to much larger values, exceeding the memory sizes of any realistically available machine/VM.

Using the documentation guidelines is resulting in miscalculations for some VM shapes/sizes and doesn't provide flexibility should the user want to deploy the toolkit with an SGA that is more than half the size of the physical memory.

Consequently, adjusting toolkit to use much more liberal setting values (albeit, still lower than the Oracle preinstall script set values) of 90% of server memory.

> Note: calculation for `kernel.shmall` is more verbose and less concise than it needs to be but provides readability while ensuring that the calculated `kernel.shmall` value, when multiplied by the page size, will always equal or be larger than the value of `kernal.shmmax` (as required).

## Testing results

Tested with several random VM shapes to ensure calculations work as expected and that database is created without issue.

From shape `n4-standard-2` with `8GB` of memory:

```plaintext
TASK [ora-host : kernel_parameters | Update other sysctl values] *******************************************************************************************************************
changed: [10.2.80.100] => (item={'parameter': 'kernel.sem', 'value': '250 32000 100 128'})
changed: [10.2.80.100] => (item={'parameter': 'kernel.shmmax', 'value': '7217558324'})
changed: [10.2.80.100] => (item={'parameter': 'kernel.shmall', 'value': '1762100'})
changed: [10.2.80.100] => (item={'parameter': 'kernel.shmmni', 'value': 4096})
...
```

From shape `n2-standard-4` with `16GB` of memory:

```plaintext
TASK [ora-host : kernel_parameters | Update other sysctl values] *******************************************************************************************************************
changed: [10.2.80.93] => (item={'parameter': 'kernel.sem', 'value': '250 32000 100 128'})
changed: [10.2.80.93] => (item={'parameter': 'kernel.shmmax', 'value': '14818266317'})
changed: [10.2.80.93] => (item={'parameter': 'kernel.shmall', 'value': '3617741'})
changed: [10.2.80.93] => (item={'parameter': 'kernel.shmmni', 'value': 4096})
...
```

From shape `n4-standard-32` with `128GB` of memory:

```plaintext
TASK [ora-host : kernel_parameters | Update other sysctl values] *******************************************************************************************************************
changed: [10.2.80.103] => (item={'parameter': 'kernel.sem', 'value': '250 32000 100 128'})
changed: [10.2.80.103] => (item={'parameter': 'kernel.shmmax', 'value': '121064914944'})
changed: [10.2.80.103] => (item={'parameter': 'kernel.shmall', 'value': '29556864'})
changed: [10.2.80.103] => (item={'parameter': 'kernel.shmmni', 'value': 4096})
...
```