### PR TITLE
Expose `--skip-database-config` to Terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -149,6 +149,7 @@ resource "google_compute_instance" "control_node" {
     ora_edition         = var.ora_edition
     ora_listener_port   = var.ora_listener_port
     ora_redo_log_size   = var.ora_redo_log_size
+    skip_database_config = var.skip_database_config
   })
 
   metadata = {

--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -70,4 +70,5 @@ bash install-oracle.sh \
 %{ if ora_release != "" }--ora-release "${ora_release}" %{ endif } \
 %{ if ora_edition != "" }--ora-edition "${ora_edition}" %{ endif } \
 %{ if ora_listener_port != "" }--ora-listener-port "${ora_listener_port}" %{ endif } \
-%{ if ora_redo_log_size != "" }--ora-redo-log-size "${ora_redo_log_size}" %{ endif }
+%{ if ora_redo_log_size != "" }--ora-redo-log-size "${ora_redo_log_size}" %{ endif } \
+%{ if skip_database_config }--skip-database-config %{ endif }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -87,4 +87,5 @@ ora_db_container  = false
 ntp_pref          = "169.254.169.254"
 ora_listener_port = "1521"
 ora_redo_log_size = "100MB"
+skip_database_config = false
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -231,3 +231,9 @@ variable "gcs_source" {
     error_message = "The gcs_source must be a valid GCS path starting with 'gs://' and ending in '.zip'."
   }
 }
+
+variable "skip_database_config" {
+  description = "Whether to skip database creation, and to simply install the Oracle software; Set to true if planning to migrate an existing database."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# The issue

The `--skip-database-config` option avoid creating a database, and this type of "software-only installs" can be especially useful when migrating a database form another system.

# The fix

Simply add the plumbing from a boolean `skip_database_config` to the `--ship-database-config` command-line parameter.  This will be our first boolean parameter in Terraform, so has slightly different syntax than the string parameters.

# Sample output

Invoked via `terraform apply` using a more or less default config, adding `skip_database_config = true`
Serial port output (including Terraform and Ansible):  https://gist.github.com/mfielding/f0f433b47df934696efefdd68e004451