### PR TITLE
Make RMAN backups optional

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1351,7 +1351,7 @@ After installation is complete, you can adjust any of the attributes of the
 backup scheme. You can also replace any and all parts of the initial backup
 scheme or the backup script with your own scripts or backup tools.
 
-#### gcsfuse backup
+#### gcsfuse backups
 
 You can use Cloud Storage buckets for Oracle rman scripts to write and store backups.
 
@@ -1959,7 +1959,10 @@ The NFS exported filesystem  should be configured with the default IDs or match 
 The configuration is done by the storage manager or systems engineer providing the remote filesystem.
 The NFS option defaults to nfsv3
 <br>
-If you are writing to a gcsfuse bucket, the /mnt must be used as parameter.</td>
+If you are writing to a gcsfuse bucket, the /mnt must be used as parameter.<br>
+If you would rather not schedule backups at all, set to an empty string "".
+The toolkit will schedule a job to periodically delete accumulated archivelog files.
+</td>
 </tr>
 <tr>
 <td>NFS backup configuration</td>

--- a/roles/db-backups/defaults/main.yml
+++ b/roles/db-backups/defaults/main.yml
@@ -19,6 +19,8 @@ logs_dir: "/home/{{ oracle_user }}/logs"
 rman_db_bu_redundancy: 2
 rman_arch_redundancy: 2
 rman_archs_online_days: 7
+# Archivelog retention when no backups are defined.
+rman_arch_retention_hours: 2
 
 full_bu_level0_day: "0"
 full_bu_level1_days: "1-6"

--- a/roles/db-backups/tasks/main.yml
+++ b/roles/db-backups/tasks/main.yml
@@ -51,6 +51,7 @@
   with_items:
     - "rman_full_backup.sh"
     - "rman_arch_backup.sh"
+    - "rman_delete_arch.sh"
     - "rman_restore_example.sh"
   tags: db-backups,add-backups
 
@@ -67,6 +68,7 @@
   with_items:
     - { level: 0, days: '{{ full_bu_level0_day }}' }
     - { level: 1, days: '{{ full_bu_level1_days }}' }
+  when: backup_dest | bool
   tags: db-backups,add-backups
 
 - name: Schedule archived redo log backups
@@ -77,6 +79,18 @@
     minute: "{{ arch_bu_start_min }}"
     user: "{{ oracle_user }}"
     job: "{{ scripts_dir }}/rman_arch_backup.sh {{ oracle_sid }} {{ rman_arch_redundancy }} {{ rman_archs_online_days }}"
+  when: backup_dest|bool
+  tags: db-backups,add-backups
+
+- name: Schedule archivelog deletion when no backups are configured
+  become: true
+  become_user: "{{ oracle_user }}"
+  cron:
+    name: "{{ oracle_sid }} archivelog deletion"
+    minute: "{{ arch_bu_start_min }}"
+    user: "{{ oracle_user }}"
+    job: "{{ scripts_dir }}/rman_delete_arch.sh {{ oracle_sid }} {{ rman_arch_retention_hours }}"
+  when: not backup_dest|bool
   tags: db-backups,add-backups
 
 - name: Run initial full backup
@@ -85,7 +99,9 @@
   shell: |
     export PATH={{ oracle_home }}/bin:/usr/local/bin:${PATH}
     {{ scripts_dir }}/rman_full_backup.sh {{ oracle_sid }} 0 {{ rman_db_bu_redundancy }} {{ rman_arch_redundancy }}
-  when: run_initial_bu|bool
+  when:
+    - backup_dest|bool
+    - run_initial_bu|bool
   register: full_backup
   tags: db-backups,run-backups
 
@@ -95,7 +111,9 @@
   shell: |
     export PATH={{ oracle_home }}/bin:/usr/local/bin:${PATH}
     {{ scripts_dir }}/rman_arch_backup.sh {{ oracle_sid }} {{ rman_arch_redundancy }} {{ rman_archs_online_days }}
-  when: run_initial_bu|bool
+  when:
+    - backup_dest|bool
+    - run_initial_bu|bool
   register: arch_backup
   tags: db-backups,run-backups
 
@@ -103,7 +121,9 @@
   debug:
     msg: "{{ item }}"
     verbosity: 1
-  when: run_initial_bu|bool
+  when:
+    - backup_dest|bool
+    - run_initial_bu|bool
   with_items:
     - "{{ full_backup }}"
     - "{{ arch_backup }}"

--- a/roles/db-backups/tasks/main.yml
+++ b/roles/db-backups/tasks/main.yml
@@ -90,7 +90,7 @@
     minute: "{{ arch_bu_start_min }}"
     user: "{{ oracle_user }}"
     job: "{{ scripts_dir }}/rman_delete_arch.sh {{ oracle_sid }} {{ rman_arch_retention_hours }}"
-  when: not backup_dest|bool
+  when: not (backup_dest|bool)
   tags: db-backups,add-backups
 
 - name: Run initial full backup

--- a/roles/db-backups/templates/rman_delete_arch.sh.j2
+++ b/roles/db-backups/templates/rman_delete_arch.sh.j2
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Example: ./rman_delete_arch.sh ORCL 2
+#
+# Variables
+#
+ora_inst_name="${1}"                     # Instance name-- should match /etc/oratab
+arch_retention_hours="${2}"              # Archivelog retention, in hours
+ts="date +%Y-%m-%d_%H-%M-%S"             # Timestamp format
+start_ts="$($ts)"                        # Start timestamp
+log_dir="{{ logs_dir }}"                 # A directory for the logs
+type="ARCHDELETE"                        # Type is archivelog deletion
+conn_str="{% if oracle_ver == "11.2.0.4.0" %}/{% else %}/ AS SYSBACKUP{% endif %}" # Oracle connection string
+fra_dest="{{ reco_destination }}"        # Fast recovery area location
+export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
+#
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 ora_inst_name arch_retention_hours" >&1
+  exit 1
+fi
+
+#
+# Check if $log_dir exists; if not, we create it
+#
+if [[ ! -d "${log_dir}" ]]; then
+  if mkdir -p "${log_dir}"; then
+    printf "\n\t%s\n\n" "INFO -- $($ts) -- ${log_dir} successfully created."
+  else
+    printf "\n\t%s\n\n" "ERROR -- $($ts) -- Impossible to create ${log_dir}; we wont be able to log this backup."
+  fi
+fi
+# If FRA is not a file system, add the ASM "+" sign (if not already added)
+if [[ "${fra_dest:0:1}" != "/" && "${fra_dest:0:1}" != "+" ]]; then
+  fra_dest="+${fra_dest}"
+fi
+#
+# We can now build the output file and log file names
+#
+outfile="${log_dir}/rman_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${start_ts}_${type}.log"
+#
+# Set the Oracle env
+#
+export ORACLE_SID="${ora_inst_name}"
+source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1
+#
+# RMAN archivelog deletion
+#
+if "${ORACLE_HOME}/bin/rman" >>"${outfile}" <<EOF
+  set echo on
+  spool log to '${logfile}'
+  connect target '${conn_str}'
+
+  configure controlfile autobackup on;
+  configure device type disk parallelism 4;
+
+  configure snapshot controlfile name to '${fra_dest}/snapcf_${ora_inst_name}.f';
+
+  run {
+    crosscheck archivelog all;
+    delete noprompt archivelog all completed before 'SYSDATE-${arch_retention_hours}/24';
+  }
+  spool log off
+EOF
+#
+# Success or error output with the name of the logfile
+#
+then
+  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} deletion of instance ${ora_inst_name} has been completed successfully."
+  printf "\t%s\n\n" "INFO -- $($ts) -- logfile used by this session: ${logfile}"
+  ret_code=0
+else
+  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} deletion of instance ${ora_inst_name} had errors, please have a look at the logfile: ${logfile}"
+  ret_code=123
+fi
+exit ${ret_code}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,10 +73,9 @@ variable "ntp_pref" {
 variable "ora_backup_dest" {
   type        = string
   description = "Backup destination for Oracle database. Example: '+RECO' or '/backup/path'. Leave empty if not needed."
-  default     = "+RECO"
 
   validation {
-    condition     = can(regex("^\\+?[A-Za-z0-9/_-]+$", var.ora_backup_dest))
+    condition     = var.ora_backup_dest == "" || can(regex("^\\+?[A-Za-z0-9/_-]+$", var.ora_backup_dest))
     error_message = "Invalid backup destination. It must be a valid ASM disk group (e.g., '+RECO') or a valid file path."
   }
 }


### PR DESCRIPTION
## The issue

Historically, the toolkit has required some sort of backup job to be configured.  But for tests and throwaway databases, backups may not be necessary.

## The fix

This change removes that requirement, allowing users to specify a blank backup destination.

We still configure archivelog mode, to support future Data Guard configurations, and to avoid the need for downtime if backups are configured in the future.  If backups are not configured, a new "backup" script `rman_delete_arch.sh` will delete accumulated archivelogs.

## Sample output

https://gist.github.com/mfielding/46c0ee664b6da705afcf194da73ef957

Test of archive deletion
https://gist.github.com/mfielding/7f0134522da3d59cf6eff50318e5c5e6
