### PR TITLE
Disambiguate task name when installing agent

### DIFF
--- a/roles/workload-agent/tasks/install.yml
+++ b/roles/workload-agent/tasks/install.yml
@@ -27,7 +27,7 @@
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
   tags: install-workload-agent
 
-- name: Install Google Cloud Agent for Compute Workloads
+- name: Install google-cloud-workload-agent package
   package:
     name: google-cloud-workload-agent
     state: latest


### PR DESCRIPTION
Right now we have two tasks with exactly the same name of "Install Google Cloud Agent for Compute Workloads"

Here we change the name of the second task, so that they're unique.