### PR TITLE
Delete public SSH key from the OS login profile

### DIFF
--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -10,6 +10,11 @@ control_node_zone="$(basename "$control_node_zone_full")"
 control_node_project_id="$(curl -s http://metadata.google.internal/computeMetadata/v1/project/project-id -H 'Metadata-Flavor: Google')"
   
 cleanup() {
+  # https://cloud.google.com/compute/docs/troubleshooting/troubleshoot-os-login#invalid_argument
+  echo "Deleting the public SSH key from the control node's service account OS Login profile to prevent exceeding the 32KiB limit"
+  if ! gcloud --quiet compute os-login ssh-keys remove --key-file=/root/.ssh/google_compute_engine.pub; then
+    echo "WARNING: Failed to remove SSH key. Continuing with instance deletion."
+  fi
   echo "Deleting '$control_node_name' GCE instance in zone '$control_node_zone' in project '$control_node_project_id'..."
   gcloud --quiet compute instances delete "$control_node_name" --zone="$control_node_zone" --project="$control_node_project_id"
 }


### PR DESCRIPTION
Remove public SSH key from the control node's service account OS Login profile.

Reason:
If many deployments are created (e.g., ~50), we risk hitting the [32KiB OS Login key limit](https://cloud.google.com/compute/docs/troubleshooting/troubleshoot-os-login#invalid_argument), which would cause the startup script to fail.

[Log from startup script](https://gist.github.com/AlexBasinov/7584dda5ff04ce2b7a9a1db25fb7d375)