### PR TITLE
Configure Google Cloud Agent for Compute Workloads to collect Oracle metrics and send them to Google Cloud Monitoring

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -68,9 +68,9 @@ Grant the service account attached to the control node VM the following IAM role
 
 ### 2. Service Account for the database VM
 
-- `roles/secretmanager.secretAccessor` - Grants access to retrieve passwords from Secret Manager.
-- `roles/monitoring.metricWriter` - Required only if the --install-workload-agent and --oracle-metrics-secret flags are set. This allows the workoload agent to write metrics to Cloud Monitoring.
-- `roles/compute.viewer` -  Required only if the --install-workload-agent and --oracle-metrics-secret flags are set. Needed by the workload agent.
+- `roles/secretmanager.secretAccessor` - Grants access to retrieve passwords from Secret Manager. Must be granted in the project containing the secrets either at the project or individual secret level.
+- `roles/monitoring.metricWriter` - Required only if the --install-workload-agent and --oracle-metrics-secret flags are set. This allows the Google Cloud Agent for Compute Workloads to write metrics to Cloud Monitoring.
+- `roles/compute.viewer` -  Required only if the --install-workload-agent and --oracle-metrics-secret flags are set. Needed by the Google Cloud Agent for Compute Workloads.
 
 ### 2. Firewall Rule for Internal IP Access
 Create a VPC firewall rule that allows ingress on TCP port 22 (or your custom SSH port) from the control node VM to the target VM.  

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -68,8 +68,9 @@ Grant the service account attached to the control node VM the following IAM role
 
 ### 2. Service Account for the database VM
 
-- `roles/secretmanager.secretAccessor` 
-   Assign this role to the service account for access to Secret Manager secrets containing the Oracle SYS and SYSTEM user passwords.
+- `roles/secretmanager.secretAccessor` - Grants access to retrieve passwords from Secret Manager.
+- `roles/monitoring.metricWriter` - Required only if the --install-workload-agent and --oracle-metrics-secret flags are set. This allows the workoload agent to write metrics to Cloud Monitoring.
+- `roles/compute.viewer` -  Required only if the --install-workload-agent and --oracle-metrics-secret flags are set. Needed by the workload agent.
 
 ### 2. Firewall Rule for Internal IP Access
 Create a VPC firewall rule that allows ingress on TCP port 22 (or your custom SSH port) from the control node VM to the target VM.  

--- a/roles/workload-agent/handlers/main.yml
+++ b/roles/workload-agent/handlers/main.yml
@@ -13,14 +13,8 @@
 # limitations under the License.
 
 ---
-- name: Install Google Cloud Agent for Compute Workloads
-  include_tasks:
-    file: install.yml
-  tags: workload-agent
-
-- name: Configure Google Cloud Agent for Compute Workloads to collect Oracle metrics and send them to Google Cloud Monitoring
-  include_tasks:
-    file: metric_collection.yml
-  when:
-    - oracle_metrics_secret | length > 0
+- name: Restart workload-agent
+  service:
+    name: google-cloud-workload-agent
+    state: restarted
   tags: workload-agent

--- a/roles/workload-agent/tasks/metric_collection.yml
+++ b/roles/workload-agent/tasks/metric_collection.yml
@@ -46,3 +46,13 @@
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
   no_log: true
   tags: workload-agent
+
+- name: Copy workload-agent's configuration file to the database VM
+  template:
+    src: "configuration.json.j2"
+    dest: "/etc/google-cloud-workload-agent/configuration.json"
+    owner: root
+    group: root
+    mode: u=rw,go=r
+  notify: Restart workload-agent
+  tags: workload-agent

--- a/roles/workload-agent/templates/configuration.json.j2
+++ b/roles/workload-agent/templates/configuration.json.j2
@@ -1,0 +1,21 @@
+{
+  "log_level": "INFO",
+  "oracle_configuration": {
+    "enabled": true,
+    "oracle_metrics": {
+      "enabled": true,
+      "connection_parameters": [
+        {
+          "host": "{{ inventory_hostname }}",
+          "port": 1521,
+          "service_name": "{{ oracle_sid }}",
+          "username": "{{ workload_agent_username }}",
+          "secret": {
+            "project_id": "{{ oracle_metrics_secret.split('/')[1] }}",
+            "secret_name": "{{ oracle_metrics_secret.split('/')[3] }}"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Configure Google Cloud Agent for Compute Workloads to collect Oracle metrics and send them to Google Cloud Monitoring.

Replaced the create_db_user.yml playbook with metric_collection.yml, which now handles the configuration of the Google Cloud Agent for Compute Workloads. This new playbook fills out the configuration.json.j2 template, copies it to the database VM, and restarts the agent to apply changes. Only connection parameters are set in the config file. All other values rely on the agent's defaults.


[Ansible log](https://gist.github.com/AlexBasinov/19cca830667b6c6f0b9af974e984fb60)
[generated configuration.json](https://gist.github.com/AlexBasinov/b25f16bb1c363127fae6849e1d0b18d9)
[agent's log](https://gist.github.com/AlexBasinov/b5995505a9a6eee466574981932266f6)
