### PR TITLE
Add `network` terraform variable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -88,7 +88,8 @@ module "instance_template" {
   name_prefix        = format("%s-template", var.instance_name)
   region             = var.region
   project_id         = local.project_id
-  subnetwork         = var.subnetwork
+  network            = coalesce(var.network, var.subnetwork)
+  subnetwork         = coalesce(var.subnetwork, var.network)
   subnetwork_project = local.project_id
   service_account = {
     email  = var.vm_service_account
@@ -119,7 +120,8 @@ module "compute_instance" {
 
   region              = var.region
   zone                = var.zone
-  subnetwork          = var.subnetwork
+  network            = coalesce(var.network, var.subnetwork)
+  subnetwork         = coalesce(var.subnetwork, var.network)
   subnetwork_project  = local.project_id
   hostname            = var.instance_name
   instance_template   = module.instance_template.self_link
@@ -155,7 +157,9 @@ resource "google_compute_instance" "control_node" {
   }
 
   network_interface {
-    network       = var.subnetwork
+    network            = coalesce(var.network, var.subnetwork)
+    subnetwork         = coalesce(var.subnetwork, var.network)
+    subnetwork_project = local.project_id
 
     dynamic "access_config" {
       for_each = var.assign_public_ip ? [1] : []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -228,10 +228,16 @@ variable "source_image_project" {
   default     = "oracle-linux-cloud"
 }
 
-variable "subnetwork" {
-  description = "The name of the GCP subnetwork to which the instance will be attached."
+variable "network" {
+  description = "The name of the GCP network to which the instance will be attached."
   type        = string
   default     = "default"
+}
+
+variable "subnetwork" {
+  description = "The name of the GCP subnetwork to which the instance will be attached; customize if using custom subnet creation mode."
+  type        = string
+  default     = ""
 }
 
 variable "zone" {


### PR DESCRIPTION
Adding a new variable `network`, that's required to support VPCs with custom subnet creation mode (https://cloud.google.com/vpc/docs/subnets).  In the default `auto` mode, network and subnetwork are the same, so taking a single parameter is fine.  But with `custom` mode, they aren't, so the caller needs to supply both.

`subnetwork` now defaults to the value of `network`.

Testcases:
https://gist.github.com/mfielding/1a08edf5295257e978dffa181fc120b7