### PR TITLE
Add validation for Terraform service accounts

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -209,11 +209,21 @@ variable "region" {
 variable "vm_service_account" {
   description = "The service account used for managing compute instance permissions."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9._-]+@[a-z0-9.-]+[.]gserviceaccount[.]com$", var.vm_service_account))
+    error_message = "vm_service_account must look like an e-mail address ending in a subdomain of gserviceaccount.com https://cloud.google.com/iam/docs/service-account-types"
+  }
 }
 
 variable "control_node_service_account" {
   description = "The service account used by the control node."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9._-]+@[a-z0-9.-]+[.]gserviceaccount[.]com$", var.control_node_service_account))
+    error_message = "control_node_service_account must look like an e-mail address ending in a subdomain of gserviceaccount.com https://cloud.google.com/iam/docs/service-account-types"
+  }
 }
 
 variable "source_image_family" {


### PR DESCRIPTION
Google service accounts has a specific form, as noted in https://cloud.google.com/iam/docs/service-account-types.  Notably, the form
`projects/myproject/serviceAccounts/123456-compute@developer.gserviceaccount.com` isn't valid.

Adding explicit, but somewhat lax, validation, to attempt to catch typical mistakes while still remaining human-readable, and to accommodate white might be future changes in service account syntax.

Testcases:

* vm_service_account=service-account-name@project-id.iam.gserviceaccount.com: success
* vm_service_account=123456-compute@developer.gserviceaccount.com: success
* vm_service_account=123456@appspot.gserviceaccount.com: success
* vm_service_account=123456@my.domain.com: failure
* vm_service_account=projects/myproject/serviceAccounts/123456-compute@developer.gserviceaccount.com: failure