### PR TITLE
Report log output as a Terraform output

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -174,13 +174,12 @@ This process will perform the following steps:
 - After configuration, the ephemeral control node is deleted to minimize resource usage.
 
 5. View startup execution logs
-   To view logs from startup script execution on the control node VM, run the following query in the Cloud Logging. Make sure to replace <my-project> and <instance-id> with your actual project ID and instance ID:
+   To view logs from startup script execution on the control node VM, fetch the
+   Terraform output variable `control_node_log_url` and paste into a browser
+   to open Logs Explorer, filtered to control node output only.
 
-```plaintext
-log_name="projects/<my-project>/logs/google_metadata_script_runner"
-resource.type="gce_instance"
-resource.labels.instance_id="<instance-id>"
-resource.labels.project_id="<my-project>"
+```bash
+terraform output control_node_log_url
 ```
 
 6. Verify Ansible Execution

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -203,3 +203,9 @@ resource "google_compute_instance" "control_node" {
 
   depends_on = [module.compute_instance]
 }
+
+output "control_node_log_url" {
+  description = "Logs Explorer URL with Oracle Toolkit output"
+  value       = "https://console.cloud.google.com/logs/query;query=resource.labels.instance_id%3D${urlencode(google_compute_instance.control_node.instance_id)};duration=P30D?project=${urlencode(var.project_id)}"
+}
+


### PR DESCRIPTION
Rather than a multi-step process of identifying the control node's instance ID and searching through logs, here we generate a pre-made log URL that will return filtered log output directly.

A sample pre-made URL from a test run:

https://console.cloud.google.com/logs/query;query=resource.labels.instance_id%3D4548656083642876608;duration=P30D?project=bmaas-testing