### PR TITLE
Validate actual `vm.nr_hugepages` values

### DIFF
--- a/roles/ora-host/tasks/hugepages.yml
+++ b/roles/ora-host/tasks/hugepages.yml
@@ -38,7 +38,7 @@
 - name: hugepages | Assert that vm.nr_hugepages matches the expected value of {{ v_hugepages_required }}
   assert:
     that:
-      - v_actual_hugepages_allocated.stdout | int == v_hugepages_required
+      - v_actual_hugepages_allocated.stdout | int == v_hugepages_required | int
     fail_msg: "Requested {{ v_hugepages_required }} hugepages to accommodate ora_sga_target_mb={{ ora_sga_target_mb }}, but only got {{ v_actual_hugepages_allocated.stdout }}.  Your requested SGA memory size is likely too large for the available memory."
 
 - name: hugepages | Capture transparent hugepage status

--- a/roles/ora-host/tasks/hugepages.yml
+++ b/roles/ora-host/tasks/hugepages.yml
@@ -18,13 +18,28 @@
   register: v_Hugepagesize
   changed_when: false
 
+- name: hugepages | Calculate number of hugepages required
+  set_fact:
+    v_hugepages_required:  "{{ ((ora_sga_target_mb | int) * 1024 / (v_Hugepagesize.stdout | int) * (hugepages_ratio | float)) | round(0,'ceil') | int }}"
+
 - name: hugepages | Update the vm.nr_hugepages sysctl value
   sysctl:
     name: "vm.nr_hugepages"
-    value: "{{ ((ora_sga_target_mb | int) * 1024 / (v_Hugepagesize.stdout | int) * (hugepages_ratio | float)) | round(0,'ceil') | int }}"
+    value: "{{ v_hugepages_required | string }}"
     state: present
     sysctl_set: true
     reload: true
+
+- name: hugepages | Fetch actual value of vm.nr_hugepages
+  command: sysctl -n vm.nr_hugepages
+  register: v_actual_hugepages_allocated
+  changed_when: false
+
+- name: hugepages | Assert that vm.nr_hugepages matches the expected value of {{ v_hugepages_required }}
+  assert:
+    that:
+      - v_actual_hugepages_allocated.stdout | int == v_hugepages_required
+    fail_msg: "Requested {{ v_hugepages_required }} hugepages to accommodate ora_sga_target_mb={{ ora_sga_target_mb }}, but only got {{ v_actual_hugepages_allocated.stdout }}.  Your requested SGA memory size is likely too large for the available memory."
 
 - name: hugepages | Capture transparent hugepage status
   shell: ( cat /sys/kernel/mm/transparent_hugepage/enabled ) || true


### PR DESCRIPTION
## The problem

While testing memory allocations for https://github.com/google/oracle-toolkit/pull/266, I realized that, if we
attempt to allocate more hugepages than the system can provide, the
command actually succeeds, allocating as many hugepages as it can.  This
is not a good outcome for us:  not only will the DB creation eventually
fail, but the install can hang due to swapping, since all free memory
has been allocated to hugepages.

## The solution

This change runs the `sysctl` OS command to get the current value, and
asserts that it matches what we asked for.

## Sample output
https://gist.github.com/mfielding/8fc8c85a1bd62240e33c72341ee16748