### PR TITLE
Remove swap readiness checks

### DIFF
--- a/roles/common/tasks/readiness_checks.yml
+++ b/roles/common/tasks/readiness_checks.yml
@@ -59,14 +59,6 @@
   when: managed_host_checks
   tags: readiness_checks
 
-- name: readiness_check | Swap space >= {{ [ansible_memtotal_mb | default(0), os_minimum_swap_mb] | min }}
-  assert:
-    that: "ansible_swaptotal_mb >= {{ [ansible_memtotal_mb | default(0), os_minimum_swap_mb] | min }}"
-    quiet: true
-    fail_msg: "Ansible fact detected swap (MB): {{ ansible_swaptotal_mb }}"
-  when: managed_host_checks
-  tags: readiness_checks
-
 - name: 'readiness_check | Validate privilege escalation ("become_user: {{ become_user_check }}") ability'
   command: whoami
   become: true


### PR DESCRIPTION
The toolkit creates and enables swap devices, but prerequisite checks run before that.  So this check will fail unless the system already has swap created and enabled prior to install (like BMS hosts, typically).

This check removes the swap check entirely to fix breakage.  We may explore ways to handle swap checks in the future.

Sample error, on a VM without pre-existing swap:

```
startup-script: fatal: [10.210.16.24]: FAILED! => {"assertion": "ansible_swaptotal_mb >= 7648", "changed": false, "evaluated_to": false, "msg": "Ansible fact detected swap (MB): 0"}
```