### PR TITLE
Add `pipelining=true` to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,6 @@
+[ssh_connection]
+pipelining                      = True
+
 [defaults]
 inventory                       = ./inventory
 deprecation_warnings            = False
@@ -11,9 +14,6 @@ retry_files_enabled             = False
 interpreter_python              = auto_legacy_silent
 command_warnings                = False
 #callback_plugins                = ./tools/callback_plugins
-
-[ssh_connection]
-pipelining                      = True
 
 #[cloud_logging]
 #project = your-project

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,6 +12,9 @@ interpreter_python              = auto_legacy_silent
 command_warnings                = False
 #callback_plugins                = ./tools/callback_plugins
 
+[ssh_connection]
+pipelining                      = True
+
 #[cloud_logging]
 #project = your-project
 #log_name = ansible_cloud_logging


### PR DESCRIPTION
## Change Description:

Add the `pipelining = True` parameter to the default `ansible.cfg` file to improve overall toolkit execution performance.

## Solution Overview:

Using `pipelining = True` can increase overall Ansible performance by minimizing the requirement for writing and using an intermediary temp-file on managed host ssh connections. Reference: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining

### Tested Toolkit Benefit

The toolkit was tested with three executions (of the four playbooks `check-instance.yml`, `prep-host.yml`, `install-sw.yml`, and `config-db.yml`) using the `pipelining = True` parameter and three executions without. For timing and instrumentation, the `callbacks_enabled = ansible.posix.profile_tasks, ansible.posix.timer, ansible.posix.profile_roles` parameters were also used.

The results of each of the three executions per configuration was averaged and compared. The result was that, for the tested `c4-standard-4` machine shape, **an overall improvement of almost 8% was achieved**. Full test details provided below.

### Risks of the Parameter Change

The reason that this parameter is not enabled by default is explained in the previously linked Ansible documentation and is summarized as it may be incompatible with the Linux sudo `requiretty` option. If this option is enabled (it is normally disabled as a default) then the `pipelining = True` Ansible parameter will result in a sudo ("become" module) error.

However, this concern is mitigated by the facts:

1. Enabling `requiretty` for sudo is likely an edge case: toolkit with this change was successfully tested against RHEL7, RHEL8, OL7, and OL8, all of which do not enable `requiretty` by default. It is unlikely that a toolkit user has enabled this sudo requirement in advance of using this toolkit.
2. Should a customer using this toolkit enable `requiretty` for sudo, the required toolkit adjustment (the "fix") is as simple as commenting out the one parameter in the `ansible.cfg` file.

The proactive "readiness_check | Validate privilege escalation ("become_user: root") ability" task already verifies privilege escalation ability, and in the case of `requiretty` for sudo being enabled on the managed host, will fail with:

```plaintext
TASK [common : readiness_check | Validate privilege escalation ("become_user: root") ability] **************************************************************************************
fatal: [10.2.80.62]: FAILED! => {"changed": false, "failed_when_result": true, "module_stderr": "sudo: sorry, you must have a tty to run sudo\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

## Timing Test Details

Timing of three test runs without `pipelining=true` (relying on parameter default):

```plaintext
2025-07-07 15:15:48,081 p=25205 u=pane n=ansible | total ------------------------------------------- 5.22s
2025-07-07 15:17:54,895 p=25259 u=pane n=ansible | total ----------------------------------------- 125.67s
2025-07-07 15:24:20,918 p=26726 u=pane n=ansible | total ----------------------------------------- 385.00s
2025-07-07 15:42:32,651 p=27291 u=pane n=ansible | total ---------------------------------------- 1090.76s
TOTAL: 1606.65

2025-07-07 15:44:12,634 p=28636 u=pane n=ansible | total ------------------------------------------- 4.28s
2025-07-07 15:46:22,886 p=28692 u=pane n=ansible | total ----------------------------------------- 129.20s
2025-07-07 15:53:13,334 p=30159 u=pane n=ansible | total ----------------------------------------- 409.28s
2025-07-07 16:11:43,937 p=30724 u=pane n=ansible | total ---------------------------------------- 1109.54s
TOTAL: 1652.30

2025-07-07 16:13:20,556 p=32083 u=pane n=ansible | total ------------------------------------------- 5.12s
2025-07-07 16:15:30,477 p=32137 u=pane n=ansible | total ----------------------------------------- 128.75s
2025-07-07 16:21:56,898 p=33603 u=pane n=ansible | total ----------------------------------------- 385.36s
2025-07-07 16:38:25,233 p=34187 u=pane n=ansible | total ----------------------------------------- 987.29s
TOTAL: 1506.52

AVG: 1588.49
```

Timing of three test runs with `pipelining=true`:

```plaintext
2025-07-07 13:45:45,412 p=19693 u=pane n=ansible | total ------------------------------------------- 3.08s
2025-07-07 13:47:27,085 p=19723 u=pane n=ansible | total ----------------------------------------- 100.53s
2025-07-07 13:53:51,482 p=20553 u=pane n=ansible | total ----------------------------------------- 383.17s
2025-07-07 14:10:15,019 p=20784 u=pane n=ansible | total ----------------------------------------- 982.51s
TOTAL: 1469.29

2025-07-07 14:11:16,262 p=21273 u=pane n=ansible | total ------------------------------------------- 2.96s
2025-07-07 14:12:51,518 p=21303 u=pane n=ansible | total ------------------------------------------ 94.23s
2025-07-07 14:19:08,190 p=22131 u=pane n=ansible | total ----------------------------------------- 375.41s
2025-07-07 14:35:28,455 p=22386 u=pane n=ansible | total ----------------------------------------- 979.26s
TOTAL: 1451.86

2025-07-07 14:36:32,307 p=22834 u=pane n=ansible | total ------------------------------------------- 4.09s
2025-07-07 14:38:08,295 p=22864 u=pane n=ansible | total ------------------------------------------ 94.90s
2025-07-07 14:44:23,310 p=23699 u=pane n=ansible | total ----------------------------------------- 373.84s
2025-07-07 15:01:02,618 p=23929 u=pane n=ansible | total ----------------------------------------- 998.16s
TOTAL: 1470.99

AVG: 1464.06
```

Improvement calculation: `(1588.49-1464.06)*100/1588.49 = 7.83 %`

## Validation of Tooling Change Against Common Linux Distributions:

- [RHEL7 Full test run output](https://gist.github.com/simonpane/455e006cd8505912432be1619f32259b)
- [RHEL8 Full test run output](https://gist.github.com/simonpane/4ff010704ae9581794af4754099de83c)
- [OL7 Full test run output](https://gist.github.com/simonpane/ddd57e6d9dcabb7b9eed4fedfb1e266e)
- [OL8 Full test run output](https://gist.github.com/simonpane/e19a60bd846aab2b48344343aeb62e36)
