### PR TITLE
Optimize tasks for playbook `check-instance.yml`

### DIFF
--- a/check-instance.yml
+++ b/check-instance.yml
@@ -13,10 +13,60 @@
 # limitations under the License.
 
 ---
-- name: Playbook pre_tasks
+- name: Playbook main tasks
   hosts: dbasm
   gather_facts: false
-  pre_tasks:
+
+  tasks:
+    - name: Test connectivity to target instance using the ping module
+      ping:
+      register: ping_result
+      ignore_unreachable: true
+
+    - name: If reachable, ensure that the ping result was "pong"
+      fail:
+        msg: "The target server did not reply properly to the ping test. Details: {{ ping_result }}"
+      when: ping_result is not defined or 'ping' not in ping_result or ping_result.ping != "pong"
+
+    - name: Show the Control Node Python interpreter
+      debug:
+        var: ansible_playbook_python
+        verbosity: 1
+
+    - name: Show the Managed Node (target host) Python interpreter
+      debug:
+        var: discovered_interpreter_python
+        verbosity: 1
+
+    - name: Check that Python is installed in the target
+      raw: |-
+        if command -v python &> /dev/null || command -v python3 &> /dev/null; then
+          exit 0
+        else
+          echo "A python installation was not detected"
+          exit 1
+        fi
+      changed_when: false
+      failed_when: false
+      register: check_python
+
+    - name: Install Python if required
+      raw: |-
+        if command -v yum &> /dev/null; then
+          sudo yum install -y python3
+        else
+          echo "The yum utility was not detected - cannot install Python"
+          exit 1
+        fi
+      when: check_python.rc != 0
+      register: python_installation
+
+    - name: Python installation output
+      debug:
+        var: python_installation
+        verbosity: 1
+
+  post_tasks:
     - name: Check environment readiness
       include_role:
         name: common
@@ -26,40 +76,3 @@
         managed_host_checks: true
         become_user_check: root
       tags: readiness_checks
-
-  tasks:
-    - name: Test connectivity to target instance via ping
-      ping:
-      register: pingrc
-
-    - name: Abort if ping module fails
-      assert:
-        that: "pingrc.ping == 'pong'"
-        fail_msg: >-
-          The instance does not have an usable python distribution
-        success_msg: >-
-          The instance has an usable python installation, continuing
-
-    - name: Collect facts from target
-      setup:
-
-    - name: Test privilege escalation on target
-      raw: sudo -u root whoami
-      register: rawrc
-      changed_when: false
-
-    - name: Fail if unable to sudo to root on target
-      assert:
-        that: "'root' in rawrc.stdout_lines"
-        fail_msg: "The account {{ ansible_user }} used to connect does not have sudo privileges to root"
-        success_msg: "The account {{ ansible_user }} used to connect has sudo root privileges, continuing"
-
-    - name: Check for Python installation
-      raw: test -e /usr/bin/python || test -e /usr/bin/python3
-      changed_when: false
-      failed_when: false
-      register: check_python
-
-    - name: Install Python if required
-      raw: sudo yum -y install python3
-      when: check_python.rc != 0


### PR DESCRIPTION
## Change Description:

Optimize checks (tasks) in the `check_instance.yml` playbook.

## Solution Overview:

Optimize the `check-instance.yml` playbook including:

- Re-structuring the logic of the `ping` module test and adjusting how failures are handled.
- Changing the ping test messages which are slightly misleading about the Python requirement.
- Implementing a more robust and flexible **python** detection.
- Changing `debug` output to have a `verbosity` key-value included.

Details and explanations of required changes are addressed below, section-by-section.

## Detailed Analysis:

### SECTION 0: Moved the "pre_tasks" section to "post_tasks"

The purpose of this playbook is to validate fundamental checks such as the managed host (aka "target instance") being reachable and having Python installed. And consequently, the normal set of `pre_tasks` should become `post_tasks` as they depend on these fundamental checks and will fail otherwise (which would then mean that if left as `pre_tasks` the actual playbook tasks would never be run).

### SECTION 1: "Test connectivity to target instance via ping"

Typically, when a managed host is unreachable, any task run against the managed host will result in an "UNREACHABLE" status (which is handled differently than the "FAILED" status). In most cases, "UNREACHABLE" should be self-explanatory and sufficiently detailed for most users to understand.

If continuing with a ping test, just running the `ping` module is likely sufficient and will report if target is unreachable, or if the system python is not found. Example:

```
TASK [Test connectivity to target instance via ping] ***********************************************************************************************************
fatal: [10.2.80.63]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: connect to host 10.2.80.63 port 22: Connection timed out", "unreachable": true}
```

In the existing block, if the server was unreachable (i.e. target is down or wrong hostname/IP address), then the `assert` module is never actually reached. Existing logic for reference:

```yaml
- name: Test connectivity to target instance via ping
  ping:
  register: pingrc

- name: Abort if ping module fails
  assert:
    that: "pingrc.ping == 'pong'"
    fail_msg: >-
      The instance does not have an usable python distribution
    success_msg: >-
      The instance has an usable python installation, continuing
```

Since the first `ping` task would result with the aforementioned "UNREACHABLE" status, the second `assert` task is never actually reached. A workaround to this would be to include the [ignore_unreachable](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_error_handling.html#ignoring-unreachable-host-errors) key.

If added, then the next issue is that the [assert](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html) module has a possibly misleading message regarding python. The Ansible documentation for the [ping](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ping_module.html) module does indeed state that Python is required on the remote node, but it is only the system `/usr/libexec/platform-python` Python that is actually required.

The system Python `/usr/libexec/platform-python` is designed for use by internal Linux systems and tools and typically is not used by applications including Ansible as it has a limited number of installed packages which many not be sufficient for the required Ansible functionality. However, in testing, the entire toolkit is technically runnable using only the system Python.

So while the existing assert block's message is technically correct, it's possibly slightly misleading.

If `/usr/libexec/platform-python` is also not available on the managed host, the result will be:

```
TASK [Test connectivity to target instance via ping] ***********************************************************************************************************
[WARNING]: No python interpreters found for host 10.2.80.101 (tried ['/usr/bin/python', 'python3.7', 'python3.6', 'python3.5', 'python2.7', 'python2.6',
'/usr/libexec/platform-python', '/usr/bin/python3', 'python'])
fatal: [10.2.80.101]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "module_stderr": "Shared connection to 10.2.80.101 closed.\r\n", "module_stdout": "/bin/sh: /usr/bin/python: No such file or directory\r\n", "msg": "The module failed to execute correctly, you probably need to set the interpreter.\nSee stdout/stderr for the exact error", "rc": 127}
```

Adding `ignore_errors: true` would result in:

```
TASK [Abort if ping module fails] ******************************************************************************************************************************
fatal: [10.2.80.101]: FAILED! => {"msg": "The conditional check 'pingrc.ping == 'pong'' failed. The error was: error while evaluating conditional (pingrc.ping == 'pong'): 'dict object' has no attribute 'ping'"}
```

Meaning that assert's `fail_msg` is not reached. Further, if the ping test is successful, then the simple "ok" task result should be sufficient over the overly verbose current `success_msg`. For example, simply:

```
TASK [Test connectivity to target instance via ping] ***********************************************************************************************************
ok: [10.2.80.101]
```

Thus, the `assert` task could be kept just in case the `ping` fails with a return code that is different to `UNREACHABLE` but the fail message could be adjusted for accuracy by removing the Python reference. However, the `assert` module is still probably overkill and using the `fail` module (to catch the edge case of the `ping` module succeeding but not returning `pong`) is probably cleaner and sufficient.

If keeping the `ping` task, and to account for some edge case possibility where a result message is provided from the `ping` module, but that message is not "pong", a `fail` module task is more appropriate. And if the `ping` module is actually successful, single "ok" task message likely sufficient and allows for more concise yet still meaningful playbook STDOUT output.

References:

- https://github.com/ansible/ansible/blob/devel/test/integration/targets/ping/tasks/main.yml
- https://github.com/ansible/ansible/blob/devel/test/integration/targets/module_precedence/lib_with_extension/ping.py

Thus the optimized tasks can become:

```yaml
- name: Test connectivity to target instance using the ping module
  ping:
  register: ping_result
  ignore_unreachable: true

- name: If reachable, ensure that the ping result was "pong"
  fail:
    msg: "The target server did not reply properly to the ping test. Details: {{ ping_result }}"
  when: ping_result is not defined or 'ping' not in ping_result or ping_result.ping != "pong"
```

The result is a concise and meaningly output that includes the critical details on failing condition.

### SECTION 2: "Collect facts from target"

Unsure of the purpose? Doesn't add anything to the playbook and can be removed.

Is possibly a left-over or remnant of a previous version of this playbook with other tasks/requirements no longer present?

### SECTION 3: "Test privilege escalation on target"

The current `sudo` based privilege escalation task has limitations such as:

- Is predicated on "**sudo**" but as mentioned in the Ansible documentation [Understanding privilege escalation: become](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html), sudo isn't the only possible privilege escalation method.
- Is predicated on the privilege escalation user being called "**root**" (which is highly likely, but not guaranteed).
- Can hang (on a background process getting a password prompt) in the sudo step: adding the `-n` option is required to prevent this.
- Looking for the word `root` in STDOUT_LINES could theoretically lead to to a false positive if matched in something like `sudo: unknown user: root`

Overall, using a test task using the `become_user` is a better test than a manual sudo for this purpose. It is more flexible and aligns with the toolkit's actual task privilege escalation method.

Doing exactly this has already been added to `readiness_checks.yml` making this further check of `sudo -u root whoami` redundant and unnecessary. Consequently removing.

### SECTION 4: "Check for Python installation"

Even if no user-Python is installed on the managed host, the task will still succeed and show as "ok":

```
TASK [Check for Python installation] ***************************************************************************************************************************
ok: [10.2.80.101]
```

This is because, as mentioned previously, the system Python `/usr/libexec/platform-python` is currently sufficient for running not just this task & playbook, but the entire toolkit.

If installing python on the managed host, then it could be added to the list of required target packages installed via the list variable defined in `roles/base-provision/defaults/main.yml` and run from `roles/base-provision/defaults/main.yml`.

Further, after installing, no option (verbosity) to display what was done (i.e. user may want to know what dependent packages were also installed) is provided:

```
TASK [Install Python if required] ******************************************************************************************************************************
changed: [10.2.80.101]
```

Therefore, this section could be optimized to the tasks:

```yaml
- name: Show the Control Node Python interpreter
  debug:
    var: ansible_playbook_python
    verbosity: 1

- name: Show the Managed Node (target host) Python interpreter
  debug:
    var: discovered_interpreter_python
    verbosity: 1

- name: Check that Python is installed in the target
  raw: |-
    if command -v python &> /dev/null || command -v python3 &> /dev/null; then
      exit 0
    else
      echo "A python installation was not detected"
      exit 1
    fi
  changed_when: false
  failed_when: false
  register: check_python

- name: Install Python if required
  raw: |-
    if command -v yum &> /dev/null; then
      sudo yum install -y python3
    else
      echo "The yum utility was not detected - cannot install Python"
      exit 1
    fi
  when: check_python.rc != 0
  register: python_installation

- name: Python installation output
  debug:
    var: python_installation
    verbosity: 1
```

These tasks:

- Use a more robust check for whether python exists on the managed host target server
- Installs it more reliably
- Shows the `ansible_playbook_python` and `discovered_interpreter_python` variables depending on verbosity
- Gives the verbosity controlled output from the installation command

Additionally, the above listed tasks could possibly be even further enhanced by replacing the `raw` modules calls with `shell` and relying on `/usr/libexec/platform-python` which should be available in all toolkit supported operating systems.

Reference: managed host Python requirements:

- Official Ansible documentation [ansible-core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)
- Third party blog [Configuring Ansible Python Interpreter](https://www.ansiblepilot.com/articles/configuring-ansible-python-interpreter/)
