### PR TITLE
Add --data-guard-protection-mode flag

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2276,14 +2276,6 @@ enabled, passwords appear in logfiles.</td>
 <td></td>
 <td>Specify one of the Data Guard protection modes: "Maximum Performance", "Maximum Availability", or "Maximum Protection".</td>
 </tr>
-<tr>
-<td></td>
-<td><p><pre>
---real-time-apply
-</pre></p></td>
-<td></td>
-<td>Whether to enable Real-Time Apply on the standby.</td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2268,6 +2268,22 @@ enabled, passwords appear in logfiles.</td>
 <td></td>
 <td>Fully qualified name of the Secret Manager secret that stores the Oracle database user's password. This user is specifically configured for the workload-agent to enable metric collection. Expected format: "projects/your-project/secrets/your-secret-name/versions/your-version"</td>
 </tr>
+<tr>
+<td></td>
+<td><p><pre>
+--data-guard-protection-mode
+</pre></p></td>
+<td></td>
+<td>Specify one of the Data Guard protection modes: "Maximum Performance", "Maximum Availability", or "Maximum Protection".</td>
+</tr>
+<tr>
+<td></td>
+<td><p><pre>
+--real-time-apply
+</pre></p></td>
+<td></td>
+<td>Whether to enable Real-Time Apply on the standby.</td>
+</tr>
 </tbody>
 </table>
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -119,7 +119,7 @@ install_workload_agent: "{{ lookup('env','INSTALL_WORKLOAD_AGENT')|lower|default
 oracle_metrics_secret: "{{ lookup('env','ORACLE_METRICS_SECRET')|lower|default('', true)}}"
 
 # Data Guard modes
-real_time_apply: "{{ lookup('env','REAL_TIME_APPLY')|lower|default(true) }}"
+real_time_apply: true
 data_guard_protection_mode: "{{ lookup('env','DATA_GUARD_PROTECTION_MODE')|lower|default('Maximum Availability', true)}}"
 log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXIMUM PERFORMANCE' else 'SYNC' }}"
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -118,6 +118,11 @@ arch_bu_start_min: "{{ lookup('env','ARCHIVE_BACKUP_MIN')|default('30',true) }}"
 install_workload_agent: "{{ lookup('env','INSTALL_WORKLOAD_AGENT')|lower|default(false) }}"
 oracle_metrics_secret: "{{ lookup('env','ORACLE_METRICS_SECRET')|lower|default('', true)}}"
 
+# Data Guard modes
+real_time_apply: "{{ lookup('env','REAL_TIME_APPLY')|lower|default(true) }}"
+data_guard_protection_mode: "{{ lookup('env','DATA_GUARD_PROTECTION_MODE')|lower|default('Maximum Availability', true)}}"
+log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXIMUM PERFORMANCE' else 'SYNC' }}"
+
 
 ## End of customizable Global Variables
 

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -285,7 +285,7 @@ GETOPT_OPTIONAL="$GETOPT_OPTIONAL,backup-start-hour:,backup-start-min:,archive-b
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-swlib-type:,ora-swlib-path:,ora-swlib-credentials:,instance-ip-addr:,primary-ip-addr:,instance-ssh-user:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,instance-ssh-key:,instance-hostname:,ntp-pref:,inventory-file:,compatible-rdbms:,instance-ssh-extra-args:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,help,validate,check-instance,prep-host,install-sw,config-db,debug,allow-install-on-vm,skip-database-config,swap-blk-device:"
-GETOPT_OPTIONAL="$GETOPT_OPTIONAL,install-workload-agent,real-time-apply,oracle-metrics-secret:,db-password-secret:,data-guard-protection-mode:"
+GETOPT_OPTIONAL="$GETOPT_OPTIONAL,install-workload-agent,oracle-metrics-secret:,db-password-secret:,data-guard-protection-mode:"
 GETOPT_LONG="$GETOPT_MANDATORY,$GETOPT_OPTIONAL"
 GETOPT_SHORT="h"
 
@@ -551,9 +551,6 @@ while true; do
     ;;
   --install-workload-agent)
     INSTALL_WORKLOAD_AGENT=true
-    ;;
-  --real-time-apply)
-    REAL_TIME_APPLY=true
     ;;
   --data-guard-protection-mode)
     DATA_GUARD_PROTECTION_MODE="$2"
@@ -1108,7 +1105,6 @@ export DB_PASSWORD_SECRET
 export INSTALL_WORKLOAD_AGENT
 export ORACLE_METRICS_SECRET
 export DATA_GUARD_PROTECTION_MODE
-export REAL_TIME_APPLY
 
 echo -e "Running with parameters from command line or environment variables:\n"
 set | grep -E '^(ORA_|BACKUP_|GCS_|ARCHIVE_|INSTANCE_|PB_|ANSIBLE_|CLUSTER|PRIMARY)' | grep -v '_PARAM='

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -875,7 +875,7 @@ if [[ -n "$ORACLE_METRICS_SECRET" && "$INSTALL_WORKLOAD_AGENT" == false ]]; then
   exit 1
 fi
 
-if [[ ! "$DATA_GUARD_PROTECTION_MODE" =~ $DATA_GUARD_PROTECTION_MODE_PARAM ]] && {
+[[ ! "$DATA_GUARD_PROTECTION_MODE" =~ $DATA_GUARD_PROTECTION_MODE_PARAM ]] && {
   echo "Incorrect parameter provided for data-guard-protection-mode: $DATA_GUARD_PROTECTION_MODE"
   echo "data-guard-protection-mode must be one of: 'Maximum Performance', 'Maximum Availability', or 'Maximum Protection'."
   exit 1

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -875,7 +875,7 @@ if [[ -n "$ORACLE_METRICS_SECRET" && "$INSTALL_WORKLOAD_AGENT" == false ]]; then
   exit 1
 fi
 
-[[ ! "$DATA_GUARD_PROTECTION_MODE" =~ $DATA_GUARD_PROTECTION_MODE_PARAM ]] && {
+[[ -n "$DATA_GUARD_PROTECTION_MODE" && ! "$DATA_GUARD_PROTECTION_MODE" =~ $DATA_GUARD_PROTECTION_MODE_PARAM ]] && {
   echo "Incorrect parameter provided for data-guard-protection-mode: $DATA_GUARD_PROTECTION_MODE"
   echo "data-guard-protection-mode must be one of: 'Maximum Performance', 'Maximum Availability', or 'Maximum Protection'."
   exit 1

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -266,6 +266,9 @@ COMPATIBLE_RDBMS_PARAM="^[0-9][0-9]\.[0-9].*"
 ORACLE_METRICS_SECRET="${ORACLE_METRICS_SECRET}"
 ORACLE_METRICS_SECRET_PARAM="^projects/[^/]+/secrets/[^/]+/versions/[^/]+$"
 
+DATA_GUARD_PROTECTION_MODE="${DATA_GUARD_PROTECTION_MODE}"
+DATA_GUARD_PROTECTION_MODE_PARAM=^(Maximum\ Performance|Maximum\ Availability|Maximum\ Protection)$
+
 
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 ###
@@ -282,7 +285,7 @@ GETOPT_OPTIONAL="$GETOPT_OPTIONAL,backup-start-hour:,backup-start-min:,archive-b
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-swlib-type:,ora-swlib-path:,ora-swlib-credentials:,instance-ip-addr:,primary-ip-addr:,instance-ssh-user:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,instance-ssh-key:,instance-hostname:,ntp-pref:,inventory-file:,compatible-rdbms:,instance-ssh-extra-args:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,help,validate,check-instance,prep-host,install-sw,config-db,debug,allow-install-on-vm,skip-database-config,swap-blk-device:"
-GETOPT_OPTIONAL="$GETOPT_OPTIONAL,install-workload-agent,oracle-metrics-secret:,db-password-secret:"
+GETOPT_OPTIONAL="$GETOPT_OPTIONAL,install-workload-agent,real-time-apply,oracle-metrics-secret:,db-password-secret:,data-guard-protection-mode:"
 GETOPT_LONG="$GETOPT_MANDATORY,$GETOPT_OPTIONAL"
 GETOPT_SHORT="h"
 
@@ -548,6 +551,13 @@ while true; do
     ;;
   --install-workload-agent)
     INSTALL_WORKLOAD_AGENT=true
+    ;;
+  --real-time-apply)
+    REAL_TIME_APPLY=true
+    ;;
+  --data-guard-protection-mode)
+    DATA_GUARD_PROTECTION_MODE="$2"
+    shift
     ;;
   --oracle-metrics-secret)
     ORACLE_METRICS_SECRET="$2"
@@ -865,6 +875,12 @@ if [[ -n "$ORACLE_METRICS_SECRET" && "$INSTALL_WORKLOAD_AGENT" == false ]]; then
   exit 1
 fi
 
+if [[ ! "$DATA_GUARD_PROTECTION_MODE" =~ $DATA_GUARD_PROTECTION_MODE_PARAM ]] && {
+  echo "Incorrect parameter provided for data-guard-protection-mode: $DATA_GUARD_PROTECTION_MODE"
+  echo "data-guard-protection-mode must be one of: 'Maximum Performance', 'Maximum Availability', or 'Maximum Protection'."
+  exit 1
+}
+
 # Parameter overrides for features that Free Edition does not support
 # (incl. RAC, ASM, role separation, and customized database name)
 if [ "${ORA_EDITION}" = "FREE" ]; then
@@ -1091,6 +1107,8 @@ export SWAP_BLK_DEVICE
 export DB_PASSWORD_SECRET
 export INSTALL_WORKLOAD_AGENT
 export ORACLE_METRICS_SECRET
+export DATA_GUARD_PROTECTION_MODE
+export REAL_TIME_APPLY
 
 echo -e "Running with parameters from command line or environment variables:\n"
 set | grep -E '^(ORA_|BACKUP_|GCS_|ARCHIVE_|INSTANCE_|PB_|ANSIBLE_|CLUSTER|PRIMARY)' | grep -v '_PARAM='

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -267,7 +267,7 @@ ORACLE_METRICS_SECRET="${ORACLE_METRICS_SECRET}"
 ORACLE_METRICS_SECRET_PARAM="^projects/[^/]+/secrets/[^/]+/versions/[^/]+$"
 
 DATA_GUARD_PROTECTION_MODE="${DATA_GUARD_PROTECTION_MODE}"
-DATA_GUARD_PROTECTION_MODE_PARAM=^(Maximum\ Performance|Maximum\ Availability|Maximum\ Protection)$
+DATA_GUARD_PROTECTION_MODE_PARAM="^(Maximum\ Performance|Maximum\ Availability|Maximum\ Protection)$"
 
 
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false

--- a/roles/dg-config/defaults/main.yml
+++ b/roles/dg-config/defaults/main.yml
@@ -13,7 +13,3 @@
 # limitations under the License.
 
 ---
-# Specify one of the Data Guard protection modes: "Maximum Performance", "Maximum Availability", or "Maximum Protection"
-data_guard_protection_mode: "Maximum Availability"
-real_time_apply: true
-log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXIMUM PERFORMANCE' else 'SYNC' }}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -197,6 +197,8 @@ resource "google_compute_instance" "control_node" {
     ora_pga_target_mb = var.ora_pga_target_mb
     ora_sga_target_mb = var.ora_sga_target_mb
     deployment_name = var.deployment_name
+    data_guard_protection_mode = var.data_guard_protection_mode
+    real_time_apply = var.real_time_apply
   })
 
   metadata = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -198,7 +198,6 @@ resource "google_compute_instance" "control_node" {
     ora_sga_target_mb = var.ora_sga_target_mb
     deployment_name = var.deployment_name
     data_guard_protection_mode = var.data_guard_protection_mode
-    real_time_apply = var.real_time_apply
   })
 
   metadata = {

--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -93,4 +93,5 @@ bash install-oracle.sh \
 %{ if ora_sga_target_mb != ""}--ora-sga-target-mb "${ora_sga_target_mb}" %{ endif } \
 %{ if install_workload_agent }--install-workload-agent %{ endif } \
 %{ if oracle_metrics_secret != "" }--oracle-metrics-secret "${oracle_metrics_secret}" %{ endif } \
-%{ if db_password_secret != "" }--db-password-secret "${db_password_secret}" %{ endif }
+%{ if data_guard_protection_mode != "" }--data-guard-protection-mode "${data_guard_protection_mode}" %{ endif } \
+%{ if real_time_apply }--real-time-apply %{ endif }

--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -93,5 +93,4 @@ bash install-oracle.sh \
 %{ if ora_sga_target_mb != ""}--ora-sga-target-mb "${ora_sga_target_mb}" %{ endif } \
 %{ if install_workload_agent }--install-workload-agent %{ endif } \
 %{ if oracle_metrics_secret != "" }--oracle-metrics-secret "${oracle_metrics_secret}" %{ endif } \
-%{ if data_guard_protection_mode != "" }--data-guard-protection-mode "${data_guard_protection_mode}" %{ endif } \
-%{ if real_time_apply }--real-time-apply %{ endif }
+%{ if data_guard_protection_mode != "" }--data-guard-protection-mode "${data_guard_protection_mode}" %{ endif }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -64,3 +64,5 @@ skip_database_config   = false
 install_workload_agent = true
 oracle_metrics_secret  = ""
 db_password_secret     = ""
+data_guard_protection_mode = "Maximum Availability"
+real_time_apply        = true

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -65,4 +65,3 @@ install_workload_agent = true
 oracle_metrics_secret  = ""
 db_password_secret     = ""
 data_guard_protection_mode = "Maximum Availability"
-real_time_apply        = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -322,3 +322,20 @@ variable "deployment_name" {
   type        = string
   default     = ""
 }
+
+variable "data_guard_protection_mode" {
+  description = "Data Guard protection mode: one of 'Maximum Performance', 'Maximum Availability', or 'Maximum Protection'."
+  type        = string
+  validation {
+    condition     = contains(["Maximum Performance", "Maximum Availability", "Maximum Protection"], var.data_guard_protection_mode)
+    error_message = "data_guard_protection_mode must be one of: 'Maximum Performance', 'Maximum Availability', or 'Maximum Protection'."
+  }
+  default = "Maximum Availability"
+}
+
+
+variable "real_time_apply" {
+  description = "Whether to enable Real-Time Apply on the standby."
+  type        = bool
+  default     = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -332,10 +332,3 @@ variable "data_guard_protection_mode" {
   }
   default = "Maximum Availability"
 }
-
-
-variable "real_time_apply" {
-  description = "Whether to enable Real-Time Apply on the standby."
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
In https://github.com/google/oracle-toolkit/pull/241, support for Data Guard protection modes was added, but it was only defined in defaults.yaml.

This change makes it configurable at deploy time by adding:

--data-guard-protection-mode flag to install-oracle.sh.

Also add matching Terraform input variable (data_guard_protection_mode) to allow passing the setting from Terraform to the install-oracle.sh script.