### PR TITLE
Add double quotes to ensure the query doesn't fail if the password contains special characters

### DIFF
--- a/roles/ora-host/tasks/validate_passwords.yml
+++ b/roles/ora-host/tasks/validate_passwords.yml
@@ -16,8 +16,8 @@
 - name: Fetch workload-agent's user password
   command: gcloud --quiet secrets versions access {{ oracle_metrics_secret }}
   register: agent_pass_result
-  changed_when: false # the command's exit code is checked in a separate task to show a clear error message.
-  failed_when: false 
+  changed_when: false 
+  failed_when: false # the command's exit code is checked in a separate task to show a clear error message.
   no_log: true # avoids leaking sensitive values in logs.
   when:
     - install_workload_agent | bool
@@ -35,7 +35,7 @@
     - agent_pass_result.rc != 0
   tags: validate-db-passwords
 
-- name: Fail if password doesn't match expected pattern
+- name: Fail if workload agent database password doesn't match expected pattern
   fail:
     msg: "Secret was fetched, but did not match expected pattern: {{ password_pattern }}"
   when:
@@ -44,11 +44,11 @@
     - not (agent_pass_result.stdout is match(password_pattern))
   tags: validate-db-passwords
 
-- name: Fetch DB password
+- name: Fetch SYS database password
   command: gcloud --quiet secrets versions access {{ db_password_secret }}
   register: sys_pass_result
   changed_when: false
-  failed_when: false
+  failed_when: false # the command's exit code is checked in a separate task to show a clear error message.
   no_log: true
   when:
     - db_password_secret | length > 0
@@ -57,12 +57,15 @@
 - name: Fail if gcloud command failed
   fail:
     msg: "Command failed: stderr={{ sys_pass_result.stderr }}"
-  when: 
+  when:
+    # Skip this task if the fetch task was skipped.
+    # sys_pass_result.skipped will be true if the fetch task didn't run due to 'when:' conditions.
+    # We use default(false) in case 'skipped' is not set (e.g. if the task ran successfully).
     - not (sys_pass_result.skipped | default(false))
     - sys_pass_result.rc != 0
   tags: validate-db-passwords
 
-- name: Fail if password doesn't match expected pattern
+- name: Fail if SYS password doesn't match expected pattern
   fail:
     msg: "Secret was fetched, but did not match expected pattern: {{ password_pattern }}"
   when:

--- a/roles/workload-agent/tasks/create_db_user.yml
+++ b/roles/workload-agent/tasks/create_db_user.yml
@@ -17,16 +17,22 @@
   command: gcloud --quiet secrets versions access {{ oracle_metrics_secret }}
   register: result
   changed_when: false
-  failed_when: >
-    (result.stdout | length == 0) or
-    ("ERROR" in result.stderr)
+  failed_when: false # the command's exit code is checked in a separate task to show a clear error message.
   no_log: true
   tags: workload-agent
 
-- name: Validate password format
+- name: Fail if gcloud command failed
   fail:
-    msg: "Invalid password format. It must match this pattern: {{ password_pattern }}"
-  when: not (result.stdout is match(password_pattern))
+    msg: "Command failed: stderr={{ result.stderr }}"
+  when: result.rc != 0
+  tags: workload-agent
+
+- name: Fail if password doesn't match expected pattern
+  fail:
+    msg: "Secret was fetched, but did not match expected pattern: {{ password_pattern }}"
+  when:
+    - result.rc == 0
+    - not (result.stdout is match(password_pattern))
   tags: workload-agent
 
 - name: Create Oracle user for Google Cloud Agent for Compute Workloads
@@ -36,7 +42,7 @@
     set -o pipefail
     sqlplus -s -L / as sysdba <<EOF
     WHENEVER SQLERROR EXIT SQL.SQLCODE;
-    CREATE USER {{ workload_agent_username }} IDENTIFIED BY {{ result.stdout }};
+    CREATE USER {{ workload_agent_username }} IDENTIFIED BY "{{ result.stdout }}";
     GRANT CREATE SESSION,SELECT_CATALOG_ROLE,SYSDG TO {{ workload_agent_username }};
     EXIT;
     EOF


### PR DESCRIPTION
Add double quotes around {{ result.stdout }} to make sure the sql query doesn't fail if the password contains special characters (@, +, ~, *).

Rename the "fail" tasks to indicate which specific password validation failed.

Add a separate "fail" task in create_db_user.yml, similar to the one in validate_passwords.yml, for consistency.

Test results:

[Successful run](https://gist.github.com/AlexBasinov/8b2f40a2e85d265fc709b54b67c3c0d7)
