### PR TITLE
parameterize control node deletion

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -251,6 +251,7 @@ resource "google_compute_instance" "control_node" {
     database_vm_nodes_json = jsonencode(local.database_vm_nodes)
     common_flags = local.common_flags
     deployment_name = var.deployment_name
+    delete_control_node = var.delete_control_node
   })
 
   metadata = {

--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -17,8 +17,10 @@ cleanup() {
   if ! gcloud --quiet compute os-login ssh-keys remove --key-file=/root/.ssh/google_compute_engine.pub; then
     echo "WARNING: Failed to remove SSH key. Continuing with instance deletion."
   fi
-  echo "Deleting '$control_node_name' GCE instance in zone '$control_node_zone' in project '$control_node_project_id'..."
-  gcloud --quiet compute instances delete "$control_node_name" --zone="$control_node_zone" --project="$control_node_project_id"
+  if [[ ${delete_control_node} == "true" ]]; then
+    echo "Deleting '$control_node_name' GCE instance in zone '$control_node_zone' in project '$control_node_project_id'..."
+    gcloud --quiet compute instances delete "$control_node_name" --zone="$control_node_zone" --project="$control_node_project_id"
+  fi
 }
 
 trap cleanup EXIT

--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -17,10 +17,10 @@ cleanup() {
   if ! gcloud --quiet compute os-login ssh-keys remove --key-file=/root/.ssh/google_compute_engine.pub; then
     echo "WARNING: Failed to remove SSH key. Continuing with instance deletion."
   fi
-  if [[ ${delete_control_node} == "true" ]]; then
-    echo "Deleting '$control_node_name' GCE instance in zone '$control_node_zone' in project '$control_node_project_id'..."
-    gcloud --quiet compute instances delete "$control_node_name" --zone="$control_node_zone" --project="$control_node_project_id"
-  fi
+  %{ if delete_control_node }
+  echo "Deleting '$control_node_name' GCE instance in zone '$control_node_zone' in project '$control_node_project_id'..."
+  gcloud --quiet compute instances delete "$control_node_name" --zone="$control_node_zone" --project="$control_node_project_id"
+  %{ endif }
 }
 
 trap cleanup EXIT

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,12 @@ variable "control_node_name_prefix" {
   default     = "control-node"
 }
 
+variable "delete_control_node" {
+  description = "Controls whether the control node deletes itself after deployment. Set to false to preserve the node for debugging purposes."
+  type        = bool
+  default     = true
+}
+
 variable "machine_type" {
   description = "The machine type to be used for the instance (e.g., n4-standard-2)."
   type        = string


### PR DESCRIPTION
Add a delete_control_node Terraform input variable to control whether the control node deletes itself after deployment. By default, the node is removed, but setting the flag to false preserves it for debugging.

Test results:

delete_control_node was set to false: https://gist.github.com/AlexBasinov/ffe96cb192237bc24b9bfafacb9c1959