### PR TITLE
Remove version and provider definitions as duplicated in versions.tf

### DIFF
--- a/terraform/backend.tf.example
+++ b/terraform/backend.tf.example
@@ -13,15 +13,6 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.10.5"
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.20.0"
-    }
-  }
-
   backend "gcs" {
     bucket = "BUCKET" # example my-state-bucket
     prefix = "PREFIX" # example dev


### PR DESCRIPTION
After the following actions:

1. `cp backend.tf.example backend.tf`
2. Updating `backend.tf`
3. `terraform init`

I observed the error below: 

```
Initializing the backend...
╷
│ Error: Terraform encountered problems during initialisation, including problems
│ with the configuration, described below.
│ 
│ The Terraform configuration must be valid before initialization so that
│ Terraform can determine which modules and providers need to be installed.
│ 
│ 
╵
╷
│ Error: Duplicate required providers configuration
│ 
│   on versions.tf line 17, in terraform:
│   17:   required_providers {
│ 
│ A module may have only one required providers configuration. The required providers were previously configured at backend.tf:18,3-21.
╵
```

This pull request removes the provider and version definitions from `backend.tf`.