### PR TITLE
Send a signal to Ansible_logs on startup failure and update Ansible logging plugin

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -129,7 +129,7 @@
   when:
     - ansible_os_family == "RedHat"
     - install_workload_agent | bool
-    - oracle_metrics_secret | length > 0
+    - oracle_metrics_secret | length > 0 or db_password_secret | length > 0
   tags: install-google-cloud-cli
 
 - name: Fetch and validate DB passwords

--- a/roles/ora-host/tasks/validate_passwords.yml
+++ b/roles/ora-host/tasks/validate_passwords.yml
@@ -26,7 +26,7 @@
 
 - name: Fail if gcloud command failed
   fail:
-    msg: "Command failed: stderr={{ agent_pass_result.stderr }}"
+    msg: "Command failed with rc={{ agent_pass_result.rc }}: stderr={{ agent_pass_result.stderr }}"
   when: 
     # Skip this task if the fetch task was skipped.
     # agent_pass_result.skipped will be true if the fetch task didn't run due to 'when:' conditions.
@@ -56,7 +56,7 @@
 
 - name: Fail if gcloud command failed
   fail:
-    msg: "Command failed: stderr={{ sys_pass_result.stderr }}"
+    msg: "Command failed with rc={{ sys_pass_result.rc }}: stderr={{ sys_pass_result.stderr }}"
   when:
     # Skip this task if the fetch task was skipped.
     # sys_pass_result.skipped will be true if the fetch task didn't run due to 'when:' conditions.

--- a/roles/workload-agent/tasks/create_db_user.yml
+++ b/roles/workload-agent/tasks/create_db_user.yml
@@ -23,7 +23,7 @@
 
 - name: Fail if gcloud command failed
   fail:
-    msg: "Command failed: stderr={{ result.stderr }}"
+    msg: "Command failed with rc={{ sys_pass_result.rc }}: stderr={{ result.stderr }}"
   when: result.rc != 0
   tags: workload-agent
 


### PR DESCRIPTION
Startup script changes:

  - A JSON log entry is now sent to the `Ansible_logs` Cloud Logging if the startup script fails.

  - The script now uses the modern `gcloud storage cp` instead of `gsutil cp`.

  - All curl commands now use the -fsS flags:
      -f ensures the script fails on HTTP errors.
      -s suppresses the progress meter.
      -S enables error messages when -s is used.
  
  - The script now uses the following idiom for command execution to ensure it exits on failure:
  
  ```
  response="$(command)" || {
    echo "error message"
    exit 1
  }
  ```
  This prevents the script from silently continuing when a command fails.

- apt-get commands now include `--quiet` and `--assume-yes` flags to reduce log noise.

- use `unzip -qq` to suppresses the output of filenames as they are extracted to reduce log noise.

- use `kill "$heartbeat_pid"` to allow the gcloud process terminate gracefully and handle its own cleanup. Also suppress any output or errors.

- Set DEBIAN_FRONTEND=noninteractive to prevent warnings like `dpkg-preconfigure: unable to re-open stdin: No such file or directory` which occur when stdin isn't available in non-interactive environments.

- Added SIGINT and SIGTERM to trap so cleanup runs on interrupt or termination, not just on EXIT.


Ansible logging plugin changes:

  - A new `error_message` field has been added to the jsonPayload. It is populated with either `result.stderr` or `result.msg` depending on the module that fails.
  
  - Set the `state` field in the jsonPayload to either "failed" or "success" based on the status of each Ansible task.


Changes in the "ora-host" role:

- Install Google Cloud cli when either `oracle-metrics-secret` or `db-password-secret` flags are provided.
- Update "Fail if gcloud command failed" Ansible tasks to log the exit code. 