### PR TITLE
Update UID and GID values to align with Oracle documentation

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -26,8 +26,8 @@ grid_base: "{{ oracle_root }}/grid"
 path_udev: asmdisks
 
 oracle_users:
-  - { name: "{{ oracle_user }}", comment: "", uid: 801, group: "{{ oracle_group }}" }
-  - { name: "{{ grid_user }}", comment: "", uid: 802, group: "{{ oracle_group }}" }
+  - { name: "{{ oracle_user }}", comment: "", uid: 54321, group: "{{ oracle_group }}" }
+  - { name: "{{ grid_user }}", comment: "", uid: 54331, group: "{{ oracle_group }}" }
 
 #
 # Groups for the oracle user
@@ -36,17 +36,17 @@ oracle_users:
 # extra_oracle_groups    : used in roles/ora-host/tasks/main.yml to be assigned to the user
 #
 oracle_groups:
-  - { group: oinstall ,       gid: 801 }
-  - { group: dba      ,       gid: 802 }
-  - { group: oper     ,       gid: 803 }
-  - { group: backupdba,       gid: 804 }
-  - { group: dgdba    ,       gid: 805 }
-  - { group: kmdba    ,       gid: 806 }
-  - { group: racdba   ,       gid: 810 }
+  - { group: oinstall ,       gid: 54321 }
+  - { group: dba      ,       gid: 54322 }
+  - { group: oper     ,       gid: 54323 }
+  - { group: backupdba,       gid: 54324 }
+  - { group: dgdba    ,       gid: 54325 }
+  - { group: kmdba    ,       gid: 54326 }
+  - { group: racdba   ,       gid: 54330 }
 
 extra_oracle_groups:
-  - { group: asmdba   ,       gid: 807 }
-  - { group: asmadmin ,       gid: 809 }
+  - { group: asmdba   ,       gid: 54327 }
+  - { group: asmadmin ,       gid: 54329 }
 
 #
 # Groups for the grid user
@@ -55,12 +55,12 @@ extra_oracle_groups:
 # extra_asm_groups    : used in roles/ora-host/tasks/main.yml to be assigned to the user
 #
 asm_groups:
-  - { group: asmdba   ,       gid: 807 }
-  - { group: asmoper  ,       gid: 808 }
-  - { group: asmadmin ,       gid: 809 }
+  - { group: asmdba   ,       gid: 54327 }
+  - { group: asmoper  ,       gid: 54328 }
+  - { group: asmadmin ,       gid: 54329 }
 
 extra_asm_groups:
-  - { group: dba      ,       gid: 802 }
+  - { group: dba      ,       gid: 54322 }
 
 asm_diskstring: "{% if asm_disk_management == 'asmlib' %}ORCL:*{% else %}/dev/{{ path_udev }}/*{% endif %}"
 


### PR DESCRIPTION
## Change Description:

Adjust the Oracle Linux OS users and groups to use the latest Oracle documentation aligned UIDs and GIDs.

## Solution Overview:

Unsure why the toolkit originally used UIDs and GIDs in the range of 801-809. This is not in alignment with the most recent Oracle documentation.

Users likely want systems provisioned in alignment with the official documentation. Latest version reference: https://docs.oracle.com/en/database/oracle/oracle-database/23/cwlin/creating-operating-system-oracle-installation-user-accounts.html

Additionally, inspecting the Oracle provided preinstall RPM we can see that it aligns with the documentation:

```base
$ sudo cat /etc/sysconfig/oracle-database-preinstall-23ai/oracle-database-preinstall-23ai.param | grep '^group:\|^username'
group:*:*:*:*:oinstall:54321
group:*:*:*:*:dba:54322
group:*:*:*:*:oper:54323
group:*:*:*:*:backupdba:54324
group:*:*:*:*:dgdba:54325
group:*:*:*:*:kmdba:54326
group:*:*:*:*:racdba:54330
username:*:*:*:*:oracle:54321:oinstall,dba,oper,backupdba,dgdba,kmdba,racdba
```

Consequently, this change simply adjusts the UIDs and GIDs used to align with the Oracle documentation and what would be created by the Oracle preinstall RPM. No other Ansible or toolkit functional changes.

## Test Commands:

Test using Enterprise Edition:

```bash
export INSTANCE_IP_ADDR=10.2.80.86

./install-oracle.sh \
 --instance-ip-addr ${INSTANCE_IP_ADDR} \
 --instance-hostname db-server19c \
 --ora-edition EE \
 --ora-version 19 \
 --ora-swlib-bucket gs://SOFTWARE_BUCKET/19c \
 --backup-dest "+RECO" \
 --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
 --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
 --no-patch

./cleanup-oracle.sh \
 --ora-version 19 \
 --inventory-file inventory_files/inventory_db-server19c_ORCL \
 --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
 --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
 --yes-i-am-sure
```

## Test Results:

Installation log:

- [Full test run output](https://gist.github.com/simonpane/9a0adcc5457f6f2a614b5159f3ac620d)

Resulting OS users/groups after installation:

```bash
$ tail -2 /etc/passwd
oracle:x:54321:54321::/home/oracle:/bin/bash
grid:x:54331:54321::/home/grid:/bin/bash

$ tail /etc/group
oinstall:x:54321:oracle
dba:x:54322:grid,oracle
oper:x:54323:oracle
backupdba:x:54324:oracle
dgdba:x:54325:oracle
kmdba:x:54326:oracle
racdba:x:54330:oracle
asmdba:x:54327:grid,oracle
asmoper:x:54328:grid
asmadmin:x:54329:grid,oracle
```
