### PR TITLE
Dynamically build `oracle_users` list based `role_separation`

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -81,7 +81,7 @@ ncharset: "{{ lookup('env','ORA_DB_NCHARSET')|default('AL16UTF16',true) }}"
 
 # ASM and storage related variables:
 asm_disk_management: "{{ lookup('env','ORA_DISK_MGMT')|lower|default('udev',true) }}"
-role_separation: "{{ lookup('env','ORA_ROLE_SEPARATION')|lower|default('true',true) }}"
+role_separation: "{{ lookup('env','ORA_ROLE_SEPARATION') | default('true') | lower | bool }}"
 data_destination: "{{ lookup('env','ORA_DATA_DESTINATION')|default('DATA',true) }}"
 reco_destination: "{{ lookup('env','ORA_RECO_DESTINATION')|default('RECO',true) }}"
 use_omf: true  # Used for file system storage (currently applicable only for Free Edition)
@@ -138,7 +138,7 @@ ora_pga_target_mb: "{{ lookup('env','ORA_PGA_TARGET_MB')|int|default('150',true)
 ora_sga_target_mb: "{{ lookup('env','ORA_SGA_TARGET_MB')|int|default((ansible_memory_mb.real.total*memory_pct)//100,true) }}"
 oracle_user: oracle
 oracle_group: oinstall
-grid_user: "{% if role_separation|bool %}grid{% else %}{{ oracle_user }}{% endif %}"
+grid_user: "{% if role_separation %}grid{% else %}{{ oracle_user }}{% endif %}"
 grid_group: asmadmin
 oracle_root: "/u01/app"
 home_name: "{% if free_edition %}dbhomeFree{% else %}dbhome_1{% endif %}"

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -200,7 +200,7 @@
     - /grid/bin
     - /grid/jdk
     - "-u {{ oracle_user }}"
-    - "{% if role_separation | bool %}-u {{ grid_user }}{% else %}[]{% endif %}"
+    - "{% if role_separation %}-u {{ grid_user }}{% else %}[]{% endif %}"
   ignore_errors: true
   register: kill_procs
   changed_when: kill_procs.rc == 0
@@ -229,7 +229,7 @@
     - /grid/bin
     - /grid/jdk
     - "-u {{ oracle_user }}"
-    - "{% if role_separation | bool %}-u {{ grid_user }}{% else %}[]{% endif %}"
+    - "{% if role_separation %}-u {{ grid_user }}{% else %}[]{% endif %}"
   ignore_errors: true
   register: kill_procs
   changed_when: kill_procs.rc == 0

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -25,9 +25,11 @@ grid_base: "{{ oracle_root }}/grid"
 
 path_udev: asmdisks
 
-oracle_users:
+rdbms_users:
   - { name: "{{ oracle_user }}", comment: "", uid: 54321, group: "{{ oracle_group }}" }
+grid_users:
   - { name: "{{ grid_user }}", comment: "", uid: 54331, group: "{{ oracle_group }}" }
+oracle_users: "{{ rdbms_users + grid_users if role_separation else rdbms_users }}"
 
 #
 # Groups for the oracle user

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -273,8 +273,7 @@
     dest: "/home/{{ grid_user }}/.bash_profile"
     marker: "# {mark} Oracle Grid Infrastructure Settings:"
     backup: true
-  when:
-    - role_separation|bool
+  when: role_separation
   tags: os-users
 
 - name: (asmlib) | ASM device managment via asmlib or udev?


### PR DESCRIPTION
## Change Description:

Fix idempotency and execution issues when `role_separation=false`

## Solution Overview:

Currently, when `role_separation=false` the toolkit will set the Oracle RDBMS and GI software owners to the same username value ("oracle"). However, it still redundantly treats them as two separate users, differing with two separate UIDs. Resulting in two successive `user:` module calls, one adding the user with the "Oracle software owner's" UID and a second with the "Grid software owner's UID".

This makes certain task non-idempotent and can even cause toolkit errors on consecutive executions. And will inadvertently create the "oracle" user with the wrong UID!

Example output showing the redundant user module calls:

```bash
TASK [ora-host : Add OS users] *****************************************************************************************************************************************************
changed: [10.2.80.121] => (item={'name': 'oracle', 'comment': '', 'uid': 801, 'group': 'oinstall'})
changed: [10.2.80.121] => (item={'name': 'oracle', 'comment': '', 'uid': 802, 'group': 'oinstall'})
```

Note that the only difference between those two lines are the "uid" values.

Example of error condition caused by running the toolkit using the option `--ora-role-separation TRUE` immediately followed by re-running using the option `--ora-role-separation FALSE` (as the "grid" user exists from the first execution and is using that UID):

```bash
TASK [ora-host : Add OS users] *****************************************************************************************************************************************************
ok: [10.2.80.121] => (item={'name': 'oracle', 'comment': '', 'uid': 801, 'group': 'oinstall'})
failed: [10.2.80.121] (item={'name': 'oracle', 'comment': '', 'uid': 802, 'group': 'oinstall'}) => {"ansible_loop_var": "item", "changed": false, "item": {"comment": "", "group": "oinstall", "name": "oracle", "uid": 802}, "msg": "usermod: UID '802' already exists\n", "name": "oracle", "rc": 4}
```

Solution is to dynamically define the `oracle_users` list: when there is role separation, it should be a list of the two distinct users; when there is not, it should only be the single user that is used in `user:` module calls.

With this PR's change in place, when installing using `role_separation=true`, only one `user:` module call is made:

```bash
TASK [ora-host : Add OS users] *****************************************************************************************************************************************************
changed: [10.2.80.121] => (item={'name': 'oracle', 'comment': '', 'uid': 801, 'group': 'oinstall'})

...
```

And similarly, the error condition is no longer encountered (after running with separation and then without).

Also changed the `role_separation` variable to be a proper boolean in this change.

## Test Commands:

### Test with Free Edition where role separation is mandatory:

Run the installation command twice to validate idempotency of the relevant tasks:

```bash
export INSTANCE_IP_ADDR=10.2.80.121

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-swlib-bucket gs://BUCKET_NAME/free-edition \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE \
  --prep-host

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-swlib-bucket gs://BUCKET_NAME/free-edition \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE

./cleanup-oracle.sh \
  --ora-edition FREE \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation FALSE \
  --yes-i-am-sure
```

### Test with Enterprise Edition:

Run the installation command twice to validate idempotency of the relevant tasks:

```bash
export INSTANCE_IP_ADDR=10.2.80.121

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://BUCKET_NAME/19c \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation FALSE \
  --prep-host

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://BUCKET_NAME/19c \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation FALSE \
  --no-patch

./cleanup-oracle.sh \
  --ora-version 19 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation FALSE \
  --yes-i-am-sure
```

### Regression test to ensure Toolkit still works with role separation:

Run the installation command twice to validate idempotency of the relevant tasks:

```bash
export INSTANCE_IP_ADDR=10.2.80.121

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://BUCKET_NAME/19c \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation TRUE \
  --prep-host

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://BUCKET_NAME/19c \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation TRUE \
  --no-patch

./cleanup-oracle.sh \
  --ora-version 19 \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --ora-role-separation TRUE \
  --yes-i-am-sure
```

## Test Results:

- [Full test run output Free Edition](https://gist.github.com/simonpane/469c7c83efa2e315dce4d58acd386c89)
- [Full test run output Enterprise Edition WITHOUT role separation](https://gist.github.com/simonpane/2a8b817add0fec39d46b09e40689cac9)
- [Full test run output Enterprise Edition WITH role separation](https://gist.github.com/simonpane/2454bb3d1f5ebdd48564d024d0c5d7a8)
