### PR TITLE
Fix issues causing 18c installation failures

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -128,7 +128,7 @@ log_transport_mode: "{{ 'ASYNC' if data_guard_protection_mode | upper == 'MAXIMU
 
 ################################################################################
 
-## Variables for adjustment in future verions - not currently modifiable
+## Variables for adjustment in future versions - not currently modifiable
 
 # DB configuration related variables:
 db_config_type: "{% if lookup('env','CLUSTER_TYPE') | default('NONE', true) in ('NONE', 'DG') %}SI{% elif lookup('env','CLUSTER_TYPE') == 'RAC' %}RAC{% endif %}"

--- a/roles/db-create/tasks/main.yml
+++ b/roles/db-create/tasks/main.yml
@@ -142,6 +142,9 @@
     - debug:
         msg: "{{ dbcalog['content'] | b64decode }}"
         verbosity: 0
+    - name: Fail due to a DBCA failure
+      fail:
+        msg: Failing due to a DBCA failure
 
 - name: DBCA output
   debug:

--- a/roles/gi-setup/tasks/asm-create.yml
+++ b/roles/gi-setup/tasks/asm-create.yml
@@ -51,7 +51,7 @@
   become_user: "{{ grid_user }}"
   tags: gi-setup,start-asm
 
-- name: asm-create | Start ASM ouput
+- name: asm-create | Start ASM output
   debug:
     msg: "{{ start_asm }}"
     verbosity: 1

--- a/roles/gi-setup/templates/init.ora.j2
+++ b/roles/gi-setup/templates/init.ora.j2
@@ -6,3 +6,4 @@
 #{{ asm_sid }}.sga_target=3G
 #{{ asm_sid }}.pga_aggregate_target=400M
 {{ asm_sid }}.processes=1024
+{% if (oracle_ver_base | float) <= 18.0 %}{{ asm_sid }}.use_large_pages=FALSE{% endif %}


### PR DESCRIPTION
## Change Description:

Oracle 18c (and below) installations failing due to insufficient hugepages. And not properly failing the playbook on DBCA errors.

## Solution Overview:

Test installation of version 18c failing with error:

```plaintext
[ 2025-08-07 13:48:13.005 EDT ] [WARNING] [DBT-06208] The 'SYS' password entered does not conform to the Oracle recommended standards.
[ 2025-08-07 13:48:13.636 EDT ] Prepare for db operation
DBCA_PROGRESS : 7%
[ 2025-08-07 13:48:15.921 EDT ] Registering database with Oracle Restart
DBCA_PROGRESS : 11%
[ 2025-08-07 13:48:16.774 EDT ] Copying database files
DBCA_PROGRESS : 12%
[ 2025-08-07 13:48:27.771 EDT ] [WARNING] ORA-27106: system pages not available to allocate memory

DBCA_PROGRESS : 13%
[ 2025-08-07 13:48:27.772 EDT ] [FATAL] ORA-01034: ORACLE not available

DBCA_PROGRESS : 33%
DBCA_PROGRESS : 100%
[ 2025-08-07 13:48:27.774 EDT ] [FATAL] ORA-01034: ORACLE not available

DBCA_PROGRESS : 11%
DBCA_PROGRESS : 7%
DBCA_PROGRESS : 0%
```

Alert log details:

```plaintext
2025-08-07T13:48:27.739230-04:00
ERROR: Failed to get available system pages to allocate memory
2025-08-07T13:48:27.739264-04:00
**********************************************************************
2025-08-07T13:48:27.739293-04:00
Dump of system resources acquired for SHARED GLOBAL AREA (SGA)

2025-08-07T13:48:27.739336-04:00
 Per process system memlock (soft) limit = UNLIMITED
2025-08-07T13:48:27.739364-04:00
 Expected per process system memlock (soft) limit to lock
 SHARED GLOBAL AREA (SGA) into memory: 6676M
2025-08-07T13:48:27.739422-04:00
 Available system pagesizes:
  4K, 2048K
2025-08-07T13:48:27.739479-04:00
 Supported system pagesize(s):
2025-08-07T13:48:27.739509-04:00
  PAGESIZE  AVAILABLE_PAGES  EXPECTED_PAGES  ALLOCATED_PAGES  ERROR(s)
2025-08-07T13:48:27.739554-04:00
     2048K             3298            3338            3293        NONE
2025-08-07T13:48:27.739581-04:00
 Reason for not supporting certain system pagesizes:
2025-08-07T13:48:27.739609-04:00
  4K - Large pagesizes only
2025-08-07T13:48:27.739642-04:00
RECOMMENDATION:
2025-08-07T13:48:27.739670-04:00
 1. Configure system with expected number of pages for every
 supported system pagesize prior to the next instance restart operation.
2025-08-07T13:48:27.742279-04:00
```

Checking the actual amount of hugepages:

```bash
# grep -E '(AnonHugePage|HugePages_Total)' /proc/meminfo
AnonHugePages:         0 kB
HugePages_Total:    3497

# grep HugePages_ /proc/meminfo
HugePages_Total:    3497
HugePages_Free:     3299
HugePages_Rsvd:        1
HugePages_Surp:        0
```

Consequently, the system is exactly 400MB short of Linux hugepages. After investigating, discovered this was due to the ASM instance consuming hugepages.

Checking the ASM memory settings between versions:

| Parameter           | 12cR2  | 18c    | 19c     |
| :------------------ | :----- | :----- | ------- |
| `memory_max_target` | `0`    | `0`    | `0`     |
| `memory_target`     | `0`    | `0`    | `0`     |
| `sga_max_size`      | `400M` | `400M` | `400M`  |
| `sga_target`        | `0`    | `0`    | `0`     |
| `use_large_pages`   | `TRUE` | `TRUE` | `FALSE` |

Consequently, the simplest solution is to set `use_large_pages=FALSE` for these older releases. Which would be in alignment with what Oracle does by default for the more recent versions.

This change includes:

- Setting `use_large_pages=FALSE` (via the jinja2 template for the ASM initialization file) for 18c and below instances.
- Ensuring that if the DBCA fails, the associated block also raises a failure.
- Minor spelling mistake corrections.

## Test Commands:

Testing an 18c installation with separate install and patch steps (i.e. using the `--no-patch` option):

```bash
export INSTANCE_IP_ADDR=10.2.80.86

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname db-server18c \
  --ora-edition EE \
  --ora-version 18 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/18c \
  --backup-dest "+RECO" \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --no-patch

./apply-patch.sh \
  --inventory-file inventory_files/inventory_db-server18c_ORCL \
  --ora-version 18 \
  --ora-release latest \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/18c
```

Testing with patching during installation (the default):

```bash
export INSTANCE_IP_ADDR=10.2.80.86

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname db-server18c \
  --ora-edition EE \
  --ora-version 18 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/18c \
  --backup-dest "+RECO" \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]'
```

## Test Results:

- [18c Installation with separate patch step](https://gist.github.com/simonpane/bacff613e91baeb87e27e12a39c2080c)
- [18c Installation with patching before DBCA](https://gist.github.com/simonpane/9520db9a76f6a891009f837d30fbd70c)
