### PR TITLE
Add format=12 flag to orapwd and show errors on failure

### DIFF
--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -211,6 +211,10 @@
           - "file={{ password_file_name }}"
           - "force=y"
           - "password={{ sys_pass }}"
+          - "format=12"
+      changed_when: false
+      failed_when: false
+      register: orapwd_result
       environment:
         ORACLE_HOME: "{{ oracle_home }}"
         ORACLE_SID: "{{ oracle_sid }}"
@@ -218,6 +222,11 @@
       become: true
       become_user: "{{ oracle_user }}"
       no_log: true
+
+    - name: orapwd command failed
+      fail:
+        msg: "exit_code={{ orapwd_result.rc }}; stderr={{ orapwd_result.stderr }}; stdout={{ orapwd_result.stdout }}"
+      when: orapwd_result.rc != 0
 
     - name: Active-copy | Generate duplicate script
       template:

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -212,8 +212,7 @@
           - "force=y"
           - "password={{ sys_pass }}"
           - "format=12"
-      changed_when: false
-      failed_when: false
+      ignore_errors: true
       register: orapwd_result
       environment:
         ORACLE_HOME: "{{ oracle_home }}"
@@ -223,9 +222,13 @@
       become_user: "{{ oracle_user }}"
       no_log: true
 
-    - name: orapwd command failed
+    - name: Active-copy | Report orapwd command failure
       fail:
-        msg: "exit_code={{ orapwd_result.rc }}; stderr={{ orapwd_result.stderr }}; stdout={{ orapwd_result.stdout }}"
+        msg: >
+          The 'orapwd' command failed.
+          Return code: {{ orapwd_result.rc }}
+          Standard error: {{ orapwd_result.stderr }}
+          Standard output: {{ orapwd_result.stdout }}
       when: orapwd_result.rc != 0
 
     - name: Active-copy | Generate duplicate script


### PR DESCRIPTION
Set `format=12` flag to bypass orapwd's password complexity checks, which can reject long and secure passwords.

Additionally, add a task to display errors from orapwd tool on failure.


Test results:


[With format=12 - orapwd completed successfully with a SYS password containing no special characters.](https://gist.github.com/AlexBasinov/9ada2a6b360dac3e250058dec2100670)
[Without format=12 - orapwd failed, reporting that the password did not meet password complexity requirement.](https://gist.github.com/AlexBasinov/f0379e42ee9f5d2930869ad416b355de)