### PR TITLE
Adding release notes template and instructions

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+# .github/release.yml
+
+changelog:  
+  categories:
+    # Category for major changes that may affect users.
+    - title: "Breaking Changes 🛠️"
+      labels:
+        - "breaking-change"
+        - "semver-major"
+        
+    # Category for new features and enhancements.
+    - title: "Exciting New Features 🎉"
+      labels:
+        - "enhancement"
+        - "feature"
+        - "semver-minor"
+        
+    # Category for bug fixes.
+    - title: "Bug Fixes 🐛"
+      labels:
+        - "bug"
+        - "fix"
+        
+    # A catch-all category for other merged pull requests.
+    - title: "Miscellaneous Changes"
+      labels:
+        - "*"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Run the destructive brute-force Oracle software removal with `cleanup-oracle.sh`
 
 Contributions and pull requests are welcome. See [docs/contributing.md](docs/contributing.md) and [docs/code-of-conduct.md](docs/code-of-conduct.md) for details.
 
+## Creating a Release
+
+1. Navigate to the Releases Page: On the main page of the repository, find the list of files and click on Releases to the right.
+2. Draft a New Release: At the top of the Releases page, click the Draft a new release button.
+3. Choose a Tag: Select the Choose a tag dropdown menu.
+4. To use a tag that already exists, simply click on the tag. To create a new tag, type in a new version number and click Create new tag.
+5. Select a Target Branch: If you created a new tag, select the Target dropdown and choose the branch you intend to release.
+6. Enter a Release Title: In the "Release title" field, type a title for your release.
+7. Generate Release Notes: Above the description field, click Generate release notes. GitHub will use the .github/release.yml file to create the changelog.
+8. Review the Notes: Check the generated notes to ensure they include all the information you want to share.
+9. Publish or Save: If the release is ready to go public, click Publish release.
+
 ## The fine print
 
 This product is [licensed](LICENSE) under the Apache 2 license. This is not an officially supported Google project


### PR DESCRIPTION
Establishing a standardized process for creating GitHub releases, complete with a configuration file for templating the release notes and a clear set of instructions follow.
Need to be iterated with improvements.
b/436612504