### PR TITLE
Fix problem with `apply-patch.sh` not using the correct `grid_user`

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -81,7 +81,7 @@ ncharset: "{{ lookup('env','ORA_DB_NCHARSET') | default('AL16UTF16',true) }}"
 
 # ASM and storage related variables:
 asm_disk_management: "{{ lookup('env','ORA_DISK_MGMT') | lower | default('udev',true) }}"
-role_separation: "{{ lookup('env','ORA_ROLE_SEPARATION') | default('true') | lower | bool }}"
+role_separation: "{{ lookup('env','ORA_ROLE_SEPARATION') | default('true', true) | lower | bool }}"
 data_destination: "{{ lookup('env','ORA_DATA_DESTINATION') | default('DATA',true) }}"
 reco_destination: "{{ lookup('env','ORA_RECO_DESTINATION') | default('RECO',true) }}"
 use_omf: true  # Used for file system storage (currently applicable only for Free Edition)

--- a/patch.yml
+++ b/patch.yml
@@ -31,6 +31,40 @@
         name: common
         tasks_from: populate-vars.yml
 
+  roles:
+    - common
+
+  tasks:
+    - name: Check if database is Oracle Restart/Clusterware configured
+      shell: |
+        set -o pipefail
+        if srvctl config database -d {{ db_name }} &>/dev/null; then
+          CLUSTERWARE_USER=$(ps -eo user,comm | awk '/(crsd|ocssd|evmd)\.bin/{print $1}' | sort -u)
+        else
+          CLUSTERWARE_USER=""
+        fi
+        echo "$CLUSTERWARE_USER"
+      environment:
+        ORACLE_HOME: "{{ oracle_home }}"
+        ORACLE_SID: "{{ oracle_sid }}"
+        PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      register: clusterware_check
+      become: true
+      become_user: "{{ oracle_user }}"
+      changed_when: false
+
+    - name: Set variables based on the Restart/Clusterware findings
+      set_fact:
+        gi_install: "{{ (clusterware_check.stdout | length) > 0 }}"
+        grid_user: "{{ clusterware_check.stdout if (clusterware_check.stdout | length) > 0 else oracle_user }}"
+
+    - name: Values for variables gi_install and grid_user
+      debug:
+        msg:
+          - "gi_install: {{ gi_install }}"
+          - "grid_user: {{ grid_user }}"
+        verbosity: 1
+
 - name: Download patches
   hosts: dbasm
   pre_tasks:


### PR DESCRIPTION
## Change Description:

Add logic to the `patch.yml` script to check for the actual `grid_user` (which can change depending on role separation or if the defaults are adjusted).

## Solution Overview:

Currently, when the GI and RDBMS homes are patched manually via the `apply-patch.sh` script (which in turn calls `patch.yml`) the subsequent patching steps are unaware of whether role separation is in use and what the name of the grid infrastructure software owner actually is. And consequently, patching may succeed or fail depending on whether the defaults match what is actually implemented on the database server.

> **NOTE:** this is not an issue when the patching happens during installation and during the execution of `install-oracle.sh` where these values are all set and have consistent values during subsequent roles and task files. This issue is unique to running from `apply-patch.sh`.

Solution is to add a few new tasks that checks whether the database to be patched is registered with Oracle Restart/Clusterware (for future compatibility where GI may not be used), and if registered, determine the actual software owner (the value for `grid_user`).

## Test Scenarios:

Tested 19c EE installations following the process:

- Installed the base software and created the database by running `install-oracle.sh` with the `--no-patch` option.
- Patched in a separate step by running `apply-patch.sh`.

Tested process with three permutations (to the `install-oracle.sh` script):

1. Including the option `--role-separation TRUE`.
2. Including the option `--role-separation FALSE`.
3. Not using the `--role-separation` option and instead relying on defaults.

## Test Results:

- [Running `apply-patch.sh` after running `install-oracle.sh` with `--role-separation TRUE`](https://gist.github.com/simonpane/a9b2ce8651d35a6d3596d88d3b5f01c7)
- [Running `apply-patch.sh` after running `install-oracle.sh` with `--role-separation FALSE`](https://gist.github.com/simonpane/a697a9a91e2d40878d47df57d586c898)
- [Running `apply-patch.sh` after running `install-oracle.sh` without using the `--role-separation` argument](https://gist.github.com/simonpane/40b731557f21ed46bbd05715c970966a)
