### PR TITLE
Collecting usage metrics if TF was used for workload agent install

### DIFF
--- a/roles/workload-agent/tasks/main.yml
+++ b/roles/workload-agent/tasks/main.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 ---
+- name: Report that Terraform was used for the installation
+  debug:
+    msg: "The agent was installed using the toolkit and Terraform was used."
+  when: is_terraform_run is defined and is_terraform_run
+
 - name: Install Google Cloud Agent for Compute Workloads
   include_tasks:
     file: install.yml

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -192,6 +192,7 @@ locals {
     length(local.asm_disk_config) > 0 ? "--ora-asm-disks-json '${jsonencode(local.asm_disk_config)}'" : "",
     length(local.data_mounts_config) > 0 ? "--ora-data-mounts-json '${jsonencode(local.data_mounts_config)}'" : "",
     "--swap-blk-device /dev/disk/by-id/google-swap",
+    "--terraform-run",
     var.ora_swlib_bucket != "" ? "--ora-swlib-bucket ${var.ora_swlib_bucket}" : "",
     var.ora_version != "" ? "--ora-version ${var.ora_version}" : "",
     var.ora_backup_dest != "" ? "--backup-dest ${var.ora_backup_dest}" : "",
@@ -252,6 +253,7 @@ resource "google_compute_instance" "control_node" {
     common_flags           = local.common_flags
     deployment_name        = var.deployment_name
     delete_control_node    = var.delete_control_node
+    is_terraform_run       = "true"
   })
 
   metadata = {


### PR DESCRIPTION
The changes involve adding a debug task to the main.yml playbook. This new task is configured to report that Terraform was used to initiate the installation of the workload agent, and it only runs when the is_terraform_run variable is explicitly set.

Buganizer: b/427723342