### PR TITLE
Catch unzip errors in multiline shell commands

### DIFF
--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -40,7 +40,7 @@
 - name: gi-install | Unzip GI patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ grid_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   args:
     creates: .gi_patch_{{ oracle_rel }}

--- a/roles/patch/tasks/rac-opatch.yml
+++ b/roles/patch/tasks/rac-opatch.yml
@@ -16,7 +16,7 @@
 - name: rac-opatch | Unzip GI patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ grid_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items: "{{ gi_patches }}"
   when: item.release == oracle_rel and item.category != "HAS_interim_patch"
@@ -195,7 +195,7 @@
 - name: rac-opatch | Unzip RDBMS patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items: "{{ rdbms_patches }}"
   when: item.release == oracle_rel

--- a/roles/rac-db-setup/tasks/rac-db-install-11.2-12.1.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install-11.2-12.1.yml
@@ -61,7 +61,7 @@
 - name: rac-db-install | Unzip OneOff patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items: "{{ rdbms_patches }}"
   when: item.release == oracle_rel

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -68,7 +68,7 @@
 - name: rac-db-install | Unzip OneOff patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items: "{{ rdbms_patches }}"
   when: item.release == oracle_rel

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -31,7 +31,7 @@
 - name: rac-gi-install | Unzip GI patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ grid_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   args:
     creates: .gi_patch_{{ oracle_rel }}

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -40,7 +40,7 @@
 - name: rdbms-install | Unzip OneOff patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
-    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}" || exit $?
     chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items: "{{ rdbms_patches }}"
   when: item.release == oracle_rel


### PR DESCRIPTION
PR #291 added performance improvements by executing unzip via `shell`.  In some of the executions, the shell command goes on to execute a `chmod` command.  But if the `unzip` command fails, we just get the return status of the `chmod` command, and miss the error.

An example from https://oss.gprow.dev/view/gs/gcp-oracle-prow-bucket/pr-logs/pull/google_oracle-toolkit/315/oracle-toolkit-install-rac-on-bms/1957573920206884864:

```
TASK [rac-db-setup : rac-db-install | Unzip OneOff patch] **********************
changed: [g370069685-s001] => (item={'category': 'RU_Combo', 'base': '19.3.0.0.0', 'release': '19.28.0.0.250715', 'patchnum': '37952382', 'patchfile': 'p37952382_190000_Linux-x86-64.zip', 'patch_subdir': '/37847857', 'prereq_check': True, 'method': 'opatch apply', 'ocm': False, 'upgrade': True, 'md5sum': 'GL89d7Hnfe+fG0kVCgcwSw=='})
changed: [g370069685-s001] => (item={'category': 'DB_OJVM_RU', 'base': '19.3.0.0.0', 'release': '19.28.0.0.250715', 'patchnum': '37952354', 'patchfile': 'p37952354_190000_Linux-x86-64.zip', 'patch_subdir': '/37847857', 'prereq_check': True, 'method': 'opatch apply', 'ocm': False, 'upgrade': True, 'md5sum': 'LRVOEDN3ODtN2WckChrM9w=='})
changed: [g370069685-s001] => (item={'category': 'DB_RU', 'base': '19.3.0.0.0', 'release': '19.28.0.0.250715', 'patchnum': '37952354', 'patchfile': 'p37952354_190000_Linux-x86-64.zip', 'patch_subdir': '/37960098', 'prereq_check': True, 'method': 'opatch apply', 'ocm': False, 'upgrade': True, 'md5sum': 'LRVOEDN3ODtN2WckChrM9w=='})
```

In this case, only the first patch exists, though all succeeded.

This change adds a `|| exit $?`, to trap errors on the first command.

For testcases, I'm going to use the prow tests, temporarily removing a required patch file, to confirm that unzip errors out.