### PR TITLE
Changes to allow Free edition RPMs to be sourced from URLs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2658,12 +2658,15 @@ Similar to with the other editions, creation of an initial database and implemen
 
 ### Free Edition Version Details
 
-Oracle has released serveral versions of free edition, often **without chaning the RPM file name**. The toolkit can install _any_ free edition version. Which version is actually installed depends on the the actual RPM file in the software library, and possibly the command line switches.
+> NOTE: Oracle has released serveral versions of Free edition, often **without chaning the RPM file name**. More recently though, they have been incorporating the version number in the file name.
 
-Specific supported versions of Oracle Database 23 free edition currently includes:
+The toolkit can install _any_ free edition version. Which version is actually installed depends on the the actual RPM file in the software library, and possibly the command line switches.
+
+Specific supported versions of Oracle Database 23 Free currently includes:
 
 | Product | Specific Version | Software RPM Filename                             | Preinstall RPM Filename                                |
 | :-----: | :--------------: | :------------------------------------------------ | :----------------------------------------------------- |
+|  23ai   |   23.9.0.25.07   | `oracle-database-free-23ai-23.9-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
 |  23ai   |   23.8.0.25.04   | `oracle-database-free-23ai-23.8-1.el8.x86_64.rpm` | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
 |  23ai   |   23.7.0.25.01   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
 |  23ai   |   23.6.0.24.10   | `oracle-database-free-23ai-1.0-1.el8.x86_64.rpm`  | `oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm` |
@@ -2672,7 +2675,35 @@ Specific supported versions of Oracle Database 23 free edition currently include
 |   23c   |   23.3.0.23.09   | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`   | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 |   23c   |    23.2.0.0.0    | `oracle-database-free-23c-1.0-1.el8.x86_64.rpm`   | `oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm`  |
 
-Even though the file names may be the same while the version changes, the RPMs for the various versions can still be staged in the software library. Possibly by manually changing the file names for uniqueness (and then updating the `rdbms_software` variable in the [roles/common/defaults/main.yml](../roles/common/defaults/main.yml) file accoridingly.) Or more simply, by placing the unique files with the same file name in different Google Cloud Storage bucket **folders**.
+The toolkit can install Oracle Database 23 Free based on software staged in your software library, or by downloading the required Oracle RPM files from the Oracle web site.
+
+To leverage files in your software library, simply include just the file names in the Ansible `rdbms_software` variable in the [roles/common/defaults/main.yml](../roles/common/defaults/main.yml). For example:
+
+```yaml
+rdbms_software:
+  - name: 23ai_free_23_8
+    version: 23.8.0.25.04
+    edition: FREE
+    files:
+      - { name: "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b", md5sum: "TmjqUT878Owv7NbXGECpTA=="}
+      - { name: "oracle-database-free-23ai-23.8-1.el8.x86_64.rpm", sha256sum: "cd0d16939150e6ec5e70999a762a13687bfa99b05c4f310593e7ca3892e1d0ce", md5sum: "hkL/hxeYbB7z5lz+3r3kww=="}
+```
+
+When installing from files staged in your software library, providing the GCS MD5 hash value is required.
+
+If you would rather have the tooling download the software from the Oracle website, simply specify the full URL instead. For example:
+
+```yaml
+rdbms_software:
+  - name: 23ai_free_23_9
+    version: 23.9.0.25.07
+    edition: FREE
+    files:
+      - { name: "https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b", md5sum: ""}
+      - { name: "https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23ai-23.9-1.el8.x86_64.rpm", sha256sum: "a6e64941ad940dd23e152e3d51213aeaea6d93b43688fbd030175935e0efe03d", md5sum: ""}
+```
+
+If installing by URL, refer to [Oracle Database Free Get Started](https://www.oracle.com/database/free/get-started/) to obtain the most recent links and `sha256sum` values.
 
 If no Free Edition version is explicitly defined (via the `--ora-version` command line switch or the corresponding environment variable), the toolkit will default to the most recent version.
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -152,6 +152,12 @@ gi_software:
       - { name: "p13390677_112040_Linux-x86-64_3of7.zip", sha256sum: "09C08AD3E1EE03DB1707F01C6221C7E3E75EC295316D0046CC5D82A65C7B928C", md5sum: "BM7zeZHbGPgZD31KGbJpEg==" }
 
 rdbms_software:
+  - name: 23ai_free_23_9
+    version: 23.9.0.25.07
+    edition: FREE
+    files:
+      - { name: "https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b", md5sum: ""}
+      - { name: "https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23ai-23.9-1.el8.x86_64.rpm", sha256sum: "a6e64941ad940dd23e152e3d51213aeaea6d93b43688fbd030175935e0efe03d", md5sum: ""}
   - name: 23ai_free_23_8
     version: 23.8.0.25.04
     edition: FREE

--- a/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
@@ -15,7 +15,7 @@
 ---
 - name: Install Oracle RPM
   package:
-    name: "{{ swlib_path }}/{{ item.name }}"
+    name: "{{ swlib_path }}/{{ item.name | basename }}"
     state: present
     lock_timeout: "{{ pkg_mgr_lock_timeout }}"
     disable_gpg_check: true

--- a/roles/swlib/tasks/gcsdirect.yml
+++ b/roles/swlib/tasks/gcsdirect.yml
@@ -131,13 +131,16 @@
   when: rdbms_patch_files is defined and rdbms_patch_files | length > 0
   changed_when: "'Date    Time    Name' not in shell_result.stdout"
 
-- name: gcsdirect | Copy RPM software from GCS to target instance
+- name: gcsdirect | Download or copy RPM software from GCS to target instance
   shell: |
     set -o pipefail
     {% for f in item.files %}
-    if ! rpm -qp "{{ swlib_path }}/{{ f.name }}"
-      then
+    if ! rpm -qp "{{ swlib_path }}/{{ f.name | basename }}"; then
+      if [[ "{{ f.name }}" == https://*oracle.com/* || "{{ f.name }}" == http://*oracle.com/* ]]; then
+        curl --location --silent --connect-timeout 20 --fail -o "{{ swlib_path }}/{{ f.name | basename }}" "{{ f.name }}" && echo "File downloaded"
+      else
         gcloud storage cp gs://{{ swlib_mount_src }}/{{ f.name }} "{{ swlib_path }}/{{ f.name }}" && echo "File copied"
+      fi
     fi
     {% endfor %}
   register: shell_result
@@ -147,4 +150,4 @@
   when:
     - item.version == oracle_ver
     - free_edition
-  changed_when: "'File copied' in shell_result.stdout"
+  changed_when: '"File downloaded" in shell_result.stdout or "File copied" in shell_result.stdout'

--- a/roles/swlib/tasks/gcstransfer.yml
+++ b/roles/swlib/tasks/gcstransfer.yml
@@ -145,15 +145,19 @@
   changed_when: "'Date    Time    Name' not in shell_result.stdout"
   delegate_to: 127.0.0.1
 
-- name: gcstransfer | Transfer RPM software from GCS to target instance
+- name: gcstransfer | Download or transfer RPM software from GCS to target instance
   shell: |
     set -o pipefail
     {% for f in item.files %}
     if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "rpm -qp {{ swlib_path }}/{{ f.name }}"
-      then
+      "rpm -qp {{ swlib_path }}/{{ f.name | basename }}"; then
+      if [[ "{{ f.name }}" == https://*oracle.com/* || "{{ f.name }}" == http://*oracle.com/* ]]; then
+        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
+          curl --location --silent --connect-timeout 20 --fail -o "{{ swlib_path }}/{{ f.name | basename }}" "{{ f.name }}" && echo "File downloaded"
+      else
         gcloud storage cat gs://"{{ swlib_mount_src }}"/"{{ f.name }}" | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
           {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ f.name }}" && echo "File copied"
+      fi
     fi
     {% endfor %}
   register: shell_result
@@ -163,5 +167,5 @@
   when:
     - item.version == oracle_ver
     - free_edition
-  changed_when: "'File copied' in shell_result.stdout"
+  changed_when: '"File downloaded" in shell_result.stdout or "File copied" in shell_result.stdout'
   delegate_to: 127.0.0.1


### PR DESCRIPTION
## Change Description:

Allow installation of Oracle Database Free via RPM download from the Oracle source website.

## Solution Overview:

Since the Oracle Database Free RPM and pre-installation RPM are both available on the Oracle [Oracle Database Free Get Started](https://www.oracle.com/database/free/get-started/) with click-through, users may want the option to not have to stage this software.

This change allows users to control whether the toolkit uses media staged in their software library or sourced from URL simply based on the `name:` key's value. Basic logic is:

- If the `name:` key value is a simple file name, then source media from the swlib
- If the `name:` key value is a URL (includes `https://*oracle.com/*`) then download files instead

For example, to use software staged in swlib:

```yaml
rdbms_software:
  - name: 23ai_free_23_8
    version: 23.8.0.25.04
    edition: FREE
    files:
      - {
          name: "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm",
          sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b",
          md5sum: "TmjqUT878Owv7NbXGECpTA==",
        }
      - {
          name: "oracle-database-free-23ai-23.8-1.el8.x86_64.rpm",
          sha256sum: "cd0d16939150e6ec5e70999a762a13687bfa99b05c4f310593e7ca3892e1d0ce",
          md5sum: "hkL/hxeYbB7z5lz+3r3kww==",
        }
```

Alternatively, to download from the Oracle hosted source:

```yaml
rdbms_software:
  - name: 23ai_free_23_9
    version: 23.9.0.25.07
    edition: FREE
    files:
      - {
          name: "https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm",
          sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b",
          md5sum: "",
        }
      - {
          name: "https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23ai-23.9-1.el8.x86_64.rpm",
          sha256sum: "a6e64941ad940dd23e152e3d51213aeaea6d93b43688fbd030175935e0efe03d",
          md5sum: "",
        }
```

The processing happens on a file-by-file basis so one file can be sourced from the swlib and the other downloaded from URL. If neither file is sourced from the swlib, then the value for `--ora-swlib-bucket` is essentially ignored and any value can be provided (as currently, a value is mandatory).

## Test Commands:

Test installation using the most recent version (default), sourced from URL (the version `23.9.0.25.07` file is not staged in the tested swlib GCS bucket):

```bash
export INSTANCE_IP_ADDR=10.2.80.43

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-swlib-bucket gs://STORAGE_BUCKET \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE
```

Test installation using a non-latest version, sourced from the swlib (URLs not provided in the `rdbms_software` variable):

```bash
export INSTANCE_IP_ADDR=10.2.80.43

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-version 23.8.0.25.04 \
  --ora-swlib-bucket gs://STORAGE_BUCKET/free-edition \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest /opt/oracle/fast_recovery_area/FREE
```

Clean-up:

```bash
./cleanup-oracle.sh \
  --ora-edition FREE \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_FREE \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --yes-i-am-sure
```

## Test Results:

- [Installation using the latest version with media sourced from URL](https://gist.github.com/simonpane/3cbfa735e57bab989f193afb6ced0e1a)
- [Installation using a non-latest version with media sourced from the swlib](https://gist.github.com/simonpane/add0213332fcfc16daa3ca54caf38280)