### PR TITLE
Documentation updates to reflect changes in Free edition software procurement options

### DIFF
--- a/docs/compute-vm-quickstart.md
+++ b/docs/compute-vm-quickstart.md
@@ -136,3 +136,20 @@ bash ./install-oracle.sh \
   --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-asm-reco-1","name":"RECO1"}]}]' \
   --ora-db-name ORCL
 ```
+
+### Oracle Database Free
+
+Provisioning [Oracle Database Free](https://www.oracle.com/database/free/) edition is even simpler. The installation automatically sources the required RPM files directly from the Oracle website, although you can still download and stage the software if you prefer. Therefore, there's no need to set up or provide the installation script with details of a Google Cloud storage bucket.
+
+Installing the software and setting up an Oracle Database Free database can be as simple as:
+
+```bash
+./install-oracle.sh \
+  --instance-ip-addr ${INSTANCE_IP_ADDR} \
+  --instance-ssh-key "${HOME}/.ssh/id_rsa_oracle_toolkit" \
+  --ora-edition FREE \
+  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
+  --backup-dest /u01/app/oracle/fast_recovery_area/FREE
+```
+
+For additional details on Oracle Database Free edition installs see the [Oracle Database Free Edition Specific Details and Changes](user-guide.md#oracle-database-free-edition-specific-details-and-changes) section of the main user guide.

--- a/docs/compute-vm-quickstart.md
+++ b/docs/compute-vm-quickstart.md
@@ -13,7 +13,9 @@ Before using this toolkit, a small number of Google Cloud prerequisites are requ
 - A [Cloud Storage bucket](https://cloud.google.com/storage/docs/buckets) where the required software media can be staged. (Details on the required software can be found in the [Downloading and staging the Oracle Software](user-guide.md#downloading-and-staging-the-oracle-software) section of the main user guide).
 - A [Compute Engine default service account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account) with the **Storage Object Viewer** (`roles/storage.objectViewer`) role on the Cloud Storage bucket.
 
-Additionally, a VM to act as the Ansible [Control Node](https://docs.ansible.com/ansible/2.9/user_guide/basic_concepts.html#control-node) with the JMESpath and Google Cloud CLI utilities installed, and the toolkit downloaded.
+> **NOTE:** This toolkit allows you to install any addition of Oracle Database including Free edition. When installing Free edition, the storage bucket prerequisites are not mandatory. See the (Oracle Database Free)[#oracle-database-free] section of this document for the quick-start installation command specific to Free edition.
+
+A VM to act as the Ansible [Control Node](https://docs.ansible.com/ansible/2.9/user_guide/basic_concepts.html#control-node) with the JMESpath and Google Cloud CLI utilities installed, and the toolkit downloaded is also required.
 
 For details on creating and configuring the Ansible Control Node see the [Ansible Control Node Provisioning & Setup](compute-vm-user-guide.md#ansible-control-node-provisioning--setup) section of the full [Oracle Toolkit for Google Cloud - Compute Engine VM User Guide](compute-vm-user-guide.md).
 

--- a/docs/compute-vm-user-guide.md
+++ b/docs/compute-vm-user-guide.md
@@ -288,6 +288,8 @@ Optionally, add the version you wish to install to the above command using the `
 
 While the toolkit is compatible with GI and ASM, the quickest and easiest start is usually to deploy Free Edition for familiarity with the toolkit and it's operation. Then complement with full EE or SE2 installations.
 
+Free edition installs will, by default, source the required RPM files directly from the Oracle website - it is not mandatory to download and stage the software in advance for this edition.
+
 For example, the simplest command to create a Free Edition database:
 
 ```bash
@@ -295,7 +297,6 @@ bash ./install-oracle.sh \
   --instance-ip-addr ${INSTANCE_IP_ADDR} \
   --instance-ssh-key "${HOME}/.ssh/id_rsa_oracle_toolkit" \
   --ora-edition free \
-  --ora-swlib-bucket gs://${BUCKET_NAME} \
   --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-u01","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
   --backup-dest /opt/oracle/fast_recovery_area/FREE
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -177,16 +177,14 @@ To create a standby database, add the following options to the command options t
 
 ## Command quick reference for Oracle Database Free Edition deployments
 
-The toolkit supports installing the Oracle Database Free edition, which is downloadable from the Oracle website: [Oracle Database Free Get Started](https://www.oracle.com/database/free/get-started/).
+The toolkit supports installing the Oracle Database Free edition, which is
+downloadable from the Oracle website: [Oracle Database Free Get Started](https://www.oracle.com/database/free/get-started/).
 
-Unlike with other Oracle Database editions, the Free edition is available in [RPM package](https://en.wikipedia.org/wiki/RPM_Package_Manager) format only. Consequently, the associated Enterprise Linux pre-installation and database RPM files must be downloaded and staged in the GCS storage bucket.
-
-1. Validate media specifying GCS storage bucket and specify `FREE` as the database edition:
-
-   ```bash
-   ./check-swlib.sh --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
-    --ora-edition FREE
-   ```
+Unlike with other Oracle Database editions, the Free edition is available in
+[RPM package](https://en.wikipedia.org/wiki/RPM_Package_Manager) format only.
+The Enterprise Linux pre-installation and database RPM files will by default
+be sourced directly from the oracle.com website. (Alternatively, they can be
+downloaded and staged in the GCS storage bucket.)
 
 1. Validate access to target server (optionally include -i and location of
    private key file):
@@ -206,7 +204,6 @@ Unlike with other Oracle Database editions, the Free edition is available in [RP
    ```bash
    ./install-oracle.sh \
    --ora-edition FREE \
-   --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
    --backup-dest [backup-directory] \
    --instance-ip-addr ${INSTANCE_IP_ADDR}
    ```
@@ -2667,7 +2664,7 @@ Similar to with the other editions, creation of an initial database and implemen
 
 > NOTE: Beginning with the April 2025 release (23.8), Oracle started using unique filenames for the Free edition, a change from their previous practice of reusing the same RPM filename for new versions.
 
-The toolkit can install _any_ free edition version. Which version is actually installed depends on the the actual RPM file in the software library, and possibly the command line switches.
+The toolkit can install _any_ free edition version. Which version is actually installed depends on the command line switches.
 
 Specific supported versions of Oracle Database 23 Free currently includes:
 


### PR DESCRIPTION
Minor documentation updates related to sourcing the Oracle Database Free RPMs from oracle.com, making use of the software library optional (for this edition only).

No functional changes to the toolkit - this PR includes documentation updates only.