### PR TITLE
Set `db_create_file_dest` when not using ASM storage

### DIFF
--- a/roles/db-create/templates/dbca.rsp.sh.j2
+++ b/roles/db-create/templates/dbca.rsp.sh.j2
@@ -37,4 +37,5 @@ else
   sed -i '/^\#\{0,\} \{0,\}storageType \{0,\}=/I             s~\#\{0,\} \{0,\}storageType \{0,\}=.*~storageType=FS~I'                                               "${response_file}"
   sed -i '/^\#\{0,\} \{0,\}datafileDestination \{0,\}=/I     s~\#\{0,\} \{0,\}datafileDestination \{0,\}=.*~datafileDestination='{{ data_destination }}'~I'         "${response_file}"
   sed -i '/^\#\{0,\} \{0,\}recoveryAreaDestination \{0,\}=/I s~\#\{0,\} \{0,\}recoveryAreaDestination \{0,\}=.*~recoveryAreaDestination='{{ reco_destination }}'~I' "${response_file}"
+  sed -i '/^\#\{0,\} \{0,\}initParams \{0,\}=/I              s~$~,db_create_file_dest='{{ data_destination }}'~'                                                    "${response_file}"
 fi


### PR DESCRIPTION
## Change Description:

Set `db_create_file_dest='{{ data_destination }}` when not using ASM -- currently defaulting to the `+DATA` disk group with ASM but is not defaulting to any value with installations into XFS storage.

## Solution Overview:

When creating databases using XFS storage, block change tracking (BCT) is not being properly enabled as the resulting Ansible task to enable it is partially failing resulting in the Ansible error block:

```plaintext
2025-08-28 11:10:33,983 p=2752 u=pane n=ansible | failed: [10.2.80.55] (item=archivelog_mode.sh) => {"ansible_loop_var": "item", "changed": true, "cmd": "/u01/swlib/archivelog_mode.sh", "delta": "0:01:11.293099", "end": "2025-08-28 11:10:33.960057", "item": "archivelog_mode.sh", "msg": "non-zero return code", "rc": 61, "start": "2025-08-28 11:09:22.666958", "stderr": "", "stderr_lines": [], "stdout": "ORACLE_SID = [oracle] ? The Oracle base has been set to /u01/app/oracle\nDatabase closed.\nDatabase dismounted.\nORACLE instance shut down.\nORACLE instance started.\n\nTotal System Global Area 6996097432 bytes\nFixed Size\t\t    9193880 bytes\nVariable Size\t\t 1224736768 bytes\nDatabase Buffers\t 5754585088 bytes\nRedo Buffers\t\t    7581696 bytes\nDatabase mounted.\n\nDatabase altered.\n\n\nDatabase altered.\n\nDatabase log mode\t       Archive Mode\nAutomatic archival\t       Enabled\nArchive destination\t       USE_DB_RECOVERY_FILE_DEST\nOldest online log sequence     32\nNext log sequence to archive   34\nCurrent log sequence\t       34\nalter database enable block change tracking\n*\nERROR at line 1:\nORA-19773: must specify change tracking file name", "stdout_lines": ["ORACLE_SID = [oracle] ? The Oracle base has been set to /u01/app/oracle", "Database closed.", "Database dismounted.", "ORACLE instance shut down.", "ORACLE instance started.", "", "Total System Global Area 6996097432 bytes", "Fixed Size\t\t    9193880 bytes", "Variable Size\t\t 1224736768 bytes", "Database Buffers\t 5754585088 bytes", "Redo Buffers\t\t    7581696 bytes", "Database mounted.", "", "Database altered.", "", "", "Database altered.", "", "Database log mode\t       Archive Mode", "Automatic archival\t       Enabled", "Archive destination\t       USE_DB_RECOVERY_FILE_DEST", "Oldest online log sequence     32", "Next log sequence to archive   34", "Current log sequence\t       34", "alter database enable block change tracking", "*", "ERROR at line 1:", "ORA-19773: must specify change tracking file name"]}
```

While there are various ways to resolve this specific issue, the one that best aligns with the ASM storage database, is to provide an initial value for `db_create_file_dest` which is used when BCT is enabled without explicitly specifying a location.  (A default value for `db_create_file_dest` is generally recommended to allow use of OMFs and is set to a disk group name when creating a database that uses ASM storage.)

## Test Results:

Test results include database checks to show parameter value and BCT file status:

- [19c on XFS test run](https://gist.github.com/simonpane/173e39b307e5732879aa1f86ed6df0bd)
- [Free edition test run](https://gist.github.com/simonpane/959b369ef0fdba8eb09c60143c609344)