### PR TITLE
Configure RAC single-instance presubmit tests to use Oracle Multitenant

### DIFF
--- a/presubmit_tests/single-instance-on-bms.sh
+++ b/presubmit_tests/single-instance-on-bms.sh
@@ -46,5 +46,5 @@ fi
 --backup-dest "+RECO" --ora-swlib-path /u01/oracle_install --ora-version 19 --ora-swlib-type gcs \
 --ora-asm-disks /etc/files_needed_for_tk/single-instance-asm.json \
 --ora-data-mounts /etc/files_needed_for_tk/single-instance-data-mounts.json --cluster-type NONE \
---ora-data-destination DATA --ora-reco-destination RECO --ora-db-name orcl --ora-db-container false \
+--ora-data-destination DATA --ora-reco-destination RECO --ora-db-name orcl --ora-db-container true \
 --instance-ip-addr "${node_ip}" --instance-hostname g322234287-s002


### PR DESCRIPTION
To get a bit more test coverage, here we configure the RAC single-instance test case (which is the faster one anyway) to set `--ora-db-container` to true, setting up multitenant.