### PR TITLE
Add new readiness check to ensure that specified storage parameter disk groups exist in `asm_disks`

### DIFF
--- a/install-sw.yml
+++ b/install-sw.yml
@@ -25,6 +25,7 @@
         control_node_checks: true
         managed_host_checks: true
         become_user_check: root
+        parameter_checks: true
       tags: readiness_checks
     - name: Determine specific release
       include_role:

--- a/prep-host.yml
+++ b/prep-host.yml
@@ -25,6 +25,7 @@
         control_node_checks: true
         managed_host_checks: true
         become_user_check: root
+        parameter_checks: true
       tags: readiness_checks
     - name: Determine specific release
       include_role:

--- a/roles/common/tasks/readiness_checks.yml
+++ b/roles/common/tasks/readiness_checks.yml
@@ -68,3 +68,15 @@
   failed_when: become_check.rc != 0 or become_check.stdout != become_user_check
   changed_when: false
   tags: readiness_checks
+
+- name: readiness_check | Verify that specified disk groups are valid
+  assert:
+    that: item in (asm_disks | map(attribute='diskgroup') | list)
+    quiet: true
+    fail_msg: "The destination '{{ item }}' is not a valid disk group from the 'asm_disks' list."
+  when:
+    - parameter_checks | default(false) | bool
+    - gi_install
+    - asm_disks is defined
+  with_items: "{{ [ data_destination | default(''), reco_destination | default('') ] | reject('equalto', '') | list }}"
+  tags: readiness_checks


### PR DESCRIPTION
Add new "readiness check" to ensure that the disk groups specified for storage (in the `--data_destination` and `--reco_destination` parameters) exist in the disk groups created using the `asm_disks` Ansible variable.

Implemented through a new "readiness check" category that is parameter focused. Specifically for use cases where checking variable validity via Ansible (verses a calling process or shell script) is required.

The check is implemented through new `assert` module task using the new control variable `parameter_checks | default(false) | bool`.

Right now, this is only technically necessary on the two playbooks `prep-host.yml` and `install-sw.yml` but in the future, could be included in others for additional parameter checks.

> **NOTE:** Checking that the `--backup-dest` value is valid is already being checked in the `roles/ora-host/tasks/main.yml` task file.

Test result: [Full test run installing 19c EE with new readiness check](https://gist.github.com/simonpane/af43a166b9128bd412acef77edecb076)