### PR TITLE
Changes to support optionally procuring software from a URL

### DIFF
--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -64,7 +64,7 @@ if [[ ! -d "${INVENTORY_DIR}" ]]; then
   fi
 fi
 #
-# Ansible logs directory, the logfile name is created later one
+# Ansible logs directory, the log file name is created later one
 #
 LOG_DIR="./logs"
 LOG_FILE="${LOG_DIR}/log"
@@ -101,7 +101,7 @@ CLUSTER_TYPE="${CLUSTER_TYPE:-NONE}"
 CLUSTER_TYPE_PARAM="NONE|RAC|DG"
 
 ORA_SWLIB_BUCKET="${ORA_SWLIB_BUCKET}"
-ORA_SWLIB_BUCKET_PARAM="^.+[^/]"
+ORA_SWLIB_BUCKET_PARAM="^(gs:\/\/|https?:\/\/)"
 
 ORA_SWLIB_TYPE="${ORA_SWLIB_TYPE:-GCS}"
 ORA_SWLIB_TYPE_PARAM="^(\"\"|GCS|GCSFUSE|NFS|GCSDIRECT|GCSTRANSFER)$"
@@ -906,6 +906,11 @@ fi
 
 if [ "${ORA_DISK_MGMT}" == "FS" ]; then
   ORA_ROLE_SEPARATION=FALSE
+fi
+
+# If downloading from GCS (or any other address) via URL
+if [[ "${ORA_SWLIB_BUCKET}" == http://* || "${ORA_SWLIB_BUCKET}" == https://* ]]; then
+  ORA_SWLIB_TYPE=URL
 fi
 
 if [[ "${skip_compatible_rdbms}" != "true" ]]; then

--- a/roles/swlib/tasks/main.yml
+++ b/roles/swlib/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: swlib | Determine required installation files
   include_tasks: build_file_list.yml
-  when: swlib_mount_type in ["gcs", "gcsdirect", "gcstransfer"]
+  when: swlib_mount_type in ["gcs", "gcsdirect", "gcstransfer", "url"]
 
 - name: swlib | Copy files from GCS directly on the Managed Host instance
   include_tasks: gcsdirect.yml
@@ -50,4 +50,10 @@
 
 - name: swlib | Use the Ansible Control Node to transfer files from GCS to the Managed Host instance
   include_tasks: gcstransfer.yml
-  when: swlib_mount_type == "gcstransfer" or gcloud_found is not defined or (gcloud_found is defined and gcloud_found.stdout != "0")
+  when: swlib_mount_type == "gcstransfer" or (gcloud_found is not defined and swlib_mount_type in ["gcs", "gcsdirect"]) or (gcloud_found.stdout is defined and gcloud_found.stdout != "0")
+
+- name: swlib | Download software from URL
+  include_tasks: url_download.yml
+  loop_control:
+    loop_var: task_file_name
+  when: swlib_mount_type == 'url'

--- a/roles/swlib/tasks/url_download.yml
+++ b/roles/swlib/tasks/url_download.yml
@@ -1,0 +1,68 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: url_download | Download OPatch
+  uri:
+    url: "{{ swlib_mount_src }}/{{ item }}"
+    dest: "{{ swlib_path }}"
+    force: yes
+    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
+    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
+    headers: "{{ lookup('env', 'URL_HEADERS') }}"
+    status_code:
+      - 200
+      - 304
+  with_items: "{{ opatch_file_list | unique }}"
+
+- name: url_download | Download base software files using file_name or alt_name
+  uri:
+    url: "{{ swlib_mount_src }}/{{ item.file_name }}"
+    dest: "{{ swlib_path }}/{{ item.file_name }}"
+    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
+    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
+    headers: "{{ lookup('env', 'URL_HEADERS') }}"
+    status_code:
+      - 200
+      - 304
+  with_items: "{{ base_sw_file_list | unique }}"
+  register: download_result
+  failed_when: download_result is failed and download_result.status not in [200, 304, 404]
+
+- name: url_download | Retry with alt_name if file_name fails
+  uri:
+    url: "{{ swlib_mount_src }}/{{ item.alt_name }}"
+    dest: "{{ swlib_path }}/{{ item.file_name }}"
+    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
+    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
+    headers: "{{ lookup('env', 'URL_HEADERS') }}"
+    status_code:
+      - 200
+      - 304
+  when:
+    - item.previous_try_status == 404
+    - not free_edition
+  with_items: "{{ download_result | json_query('results[*].{file_name:item.file_name,alt_name:item.alt_name,previous_try_status:status}') }}"
+
+- name: url_download | Download patch files
+  uri:
+    url: "{{ swlib_mount_src }}/{{ item }}"
+    dest: "{{ swlib_path }}/{{ item }}"
+    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
+    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
+    headers: "{{ lookup('env', 'URL_HEADERS') }}"
+    status_code:
+      - 200
+      - 304
+  with_items: "{{ patch_file_list | unique }}"

--- a/roles/swlib/tasks/url_download.yml
+++ b/roles/swlib/tasks/url_download.yml
@@ -18,8 +18,6 @@
     url: "{{ swlib_mount_src }}/{{ item }}"
     dest: "{{ swlib_path }}"
     force: yes
-    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
-    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
     headers: "{{ lookup('env', 'URL_HEADERS') }}"
     status_code:
       - 200
@@ -30,8 +28,6 @@
   uri:
     url: "{{ swlib_mount_src }}/{{ item.file_name }}"
     dest: "{{ swlib_path }}/{{ item.file_name }}"
-    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
-    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
     headers: "{{ lookup('env', 'URL_HEADERS') }}"
     status_code:
       - 200
@@ -44,8 +40,6 @@
   uri:
     url: "{{ swlib_mount_src }}/{{ item.alt_name }}"
     dest: "{{ swlib_path }}/{{ item.file_name }}"
-    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
-    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
     headers: "{{ lookup('env', 'URL_HEADERS') }}"
     status_code:
       - 200
@@ -59,8 +53,6 @@
   uri:
     url: "{{ swlib_mount_src }}/{{ item }}"
     dest: "{{ swlib_path }}/{{ item }}"
-    url_username: "{{ lookup('env', 'URL_USERNAME') }}"
-    url_password: "{{ lookup('env', 'URL_PASSWORD') }}"
     headers: "{{ lookup('env', 'URL_HEADERS') }}"
     status_code:
       - 200


### PR DESCRIPTION
## Change Description:

Allow (undocumented) option to download software from a URL based location.

## Solution Overview:

Instead of using a GCS bucket, some customers may potentially want the ability to download the software from some internally staged, and URL accessed, private location or artifact repository. Such as `https://media.company.com`.

This change will detect if the `--ora-swlib-bucket` value provided begins with `http://` or `https://` and if so, will procure the software using the Ansible `uri` module.

Optional parameters to the `uri` module can be provided as as **OS environment variables** as required. Including: `URL_USERNAME`, `URL_PASSWORD` and `URL_HEADERS`. The latter must be in the form of properly formed JSON.

Example of setting the `URL_HEADERS` OS environment variable (in this example accessing a GCS bucket via URL simply for the purpose of demonstrating this functionality):

```bash
export TOKEN=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" -H "Metadata-Flavor: Google" | jq -r .access_token)
export URL_HEADERS="{\"Authorization\": \"Bearer ${TOKEN}\"}"
echo ${URL_HEADERS} | jq -r '.'
```

Then run the rest of the toolkit installation as normal, the only exception being the URL-based source location. For example:

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket https://storage.googleapis.com/pythian-gto-oracle-software/19c/ \
  --ora-asm-disks-json '[{"diskgroup":"DATA","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-data-1","name":"DATA1"}]},{"diskgroup":"RECO","disks":[{"blk_device":"/dev/disk/by-id/google-oracle-reco-1" ,"name":"RECO1"}]}]' \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"}]' \
  --backup-dest "+RECO"
```

> **NOTE:** The other OS environment variables `URL_USERNAME` and `URL_PASSWORD` can be left undefined but are included in the Ansible tasks for their optional usage and advance-user reference.

## Test Results:

- [Free Edition install using Ansible 2.9](https://gist.github.com/simonpane/78a8bef6a07e2275b0cb64fd44ac0497)
- [Installation of 19c EE with Day 2 patching](https://gist.github.com/simonpane/ac1ac5bcba5297235142c5ee85c373bd)