### PR TITLE
Changes to support installing Free edition on EL9 with new `os_version` key-value in `rdbms_software`

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -155,48 +155,63 @@ rdbms_software:
   - name: 23ai_free_23_9
     version: 23.9.0.25.07
     edition: FREE
+    os_version: 9
+    files:
+      - { name: "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/getPackage/oracle-database-preinstall-23ai-1.0-2.el9.x86_64.rpm", sha256sum: "aa7bc3a62f4118cc8e02ece2f67ddd276b2256833e4d66f939725b2ef22bebf9", md5sum: "6opRa2Ug+YMZaITFabPt0g=="}
+      - { name: "https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23ai-23.9-1.el9.x86_64.rpm", sha256sum: "35a5b2e4065747eea3258d4f0c8d9a6e5440a818945da183fc631750cce4d999", md5sum: "HiohdiKUMAHK/ejTxJR72w=="}
+  - name: 23ai_free_23_9
+    version: 23.9.0.25.07
+    edition: FREE
+    os_version: 8
     files:
       - { name: "https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b", md5sum: "TmjqUT878Owv7NbXGECpTA=="}
       - { name: "https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23ai-23.9-1.el8.x86_64.rpm", sha256sum: "a6e64941ad940dd23e152e3d51213aeaea6d93b43688fbd030175935e0efe03d", md5sum: "ZvqO1/Cii+HBaLbtILQHPw=="}
   - name: 23ai_free_23_8
     version: 23.8.0.25.04
     edition: FREE
+    os_version: 8
     files:
       - { name: "https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578e6d1cf566e04541e0216b07a0372725726a7c339423ee560255cb918138b", md5sum: "TmjqUT878Owv7NbXGECpTA=="}
       - { name: "https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23ai-23.8-1.el8.x86_64.rpm", sha256sum: "cd0d16939150e6ec5e70999a762a13687bfa99b05c4f310593e7ca3892e1d0ce", md5sum: "hkL/hxeYbB7z5lz+3r3kww=="}
   - name: 23ai_free_23_7
     version: 23.7.0.25.01
     edition: FREE
+    os_version: 8
     files:
       - { name: "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578E6D1CF566E04541E0216B07A0372725726A7C339423EE560255CB918138B", md5sum: "TmjqUT878Owv7NbXGECpTA==" }
       - { name: "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm",  sha256sum: "AF64450E1120E56DAC43A447A2E109449C7590489003D830D6A32A9168E0469D", md5sum: "a838g/xuUjrVkzM2S5AUug==" }
   - name: 23ai_free_23_6
     version: 23.6.0.24.10
     edition: FREE
+    os_version: 8
     files:
       - { name: "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578E6D1CF566E04541E0216B07A0372725726A7C339423EE560255CB918138B", md5sum: "TmjqUT878Owv7NbXGECpTA=="}
       - { name: "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm", sha256sum: "03AE958784E9443C0380E4D387CB0522016C72D029AB85CF55EE124489833E0E", md5sum: "Y70TVN1a7dV6TnNOeN1pYA==" }
   - name: 23ai_free_23_5
     version: 23.5.0.24.07
     edition: FREE
+    os_version: 8
     files:
       - { name: "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578E6D1CF566E04541E0216B07A0372725726A7C339423EE560255CB918138B", md5sum: "TmjqUT878Owv7NbXGECpTA==" }
       - { name: "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm", sha256sum: "80C1CEAE3B158CFFE71FA4CFA8E4F540161659F79F777BCF48935F79031C054C", md5sum: "cWcZFOhqt4Bnwt4rft6wpw==" }
   - name: 23ai_free_23_4
     version: 23.4.0.24.05
     edition: FREE
+    os_version: 8
     files:
       - { name: "oracle-database-preinstall-23ai-1.0-2.el8.x86_64.rpm", sha256sum: "4578E6D1CF566E04541E0216B07A0372725726A7C339423EE560255CB918138B", md5sum: "TmjqUT878Owv7NbXGECpTA==" }
       - { name: "oracle-database-free-23ai-1.0-1.el8.x86_64.rpm", sha256sum: "E6CCCEC7F101325C233F374C2AA86F77D62123EDD3125450D79404C3EEC30B65", md5sum: "nZiDvGPHVa8iDkR110gB8A==" }
   - name: 23c_free_23_3
     version: 23.3.0.23.09
     edition: FREE
+    os_version: 8
     files:
       - { name: "oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm", sha256sum: "F41059C22A610A2180CC6286179A7DA148BFE14B0D88211F006C9998CE03BA0E", md5sum: "lVoplyvF66eUXign+DuZ8Q==" }
       - { name: "oracle-database-free-23c-1.0-1.el8.x86_64.rpm", sha256sum: "1319BCD7CB706CB727501CBD98ABF3F3980A4FDABEB613A1ABFFC756925C7374", md5sum: "k+q8twMOziARmih9mF79ow==" }
   - name: 23c_free_23_2
     version: 23.2.0.0.0
     edition: FREE
+    os_version: 8
     files:
       - { name: "oracle-database-preinstall-23c-1.0-1.el8.x86_64.rpm", sha256sum: "F41059C22A610A2180CC6286179A7DA148BFE14B0D88211F006C9998CE03BA0E", md5sum: "lVoplyvF66eUXign+DuZ8Q==" }
       - { name: "oracle-database-free-23c-1.0-1.el8.x86_64.rpm", sha256sum: "63B6C0EC9464682CFD9814E7E2A5D533139E5C6AEB9D3E7997A5F976D6677CA6", md5sum: "RRinLLsJM2hpuFcE+3zURA==" }
@@ -205,6 +220,9 @@ rdbms_software:
     edition:
       - EE
       - SE2
+    os_version:
+      - 8
+      - 7
     files:
       - { name: "V1011496-01.zip", sha256sum: "C05D5C32A72B9BF84AB6BABB49AEE99CBB403930406AABE3CF2F94F1D35E0916", md5sum: "iskVqACADd8Wo4JQbTlT2w==",
           alt_name: "LINUX.X64_213000_db_home.zip", alt_sha256sum: "C05D5C32A72B9BF84AB6BABB49AEE99CBB403930406AABE3CF2F94F1D35E0916", alt_md5sum: "iskVqACADd8Wo4JQbTlT2w==" }
@@ -213,6 +231,9 @@ rdbms_software:
     edition:
       - EE
       - SE2
+    os_version:
+      - 8
+      - 7
     files:
       - { name: "V982063-01.zip", sha256sum: "BA8329C757133DA313ED3B6D7F86C5AC42CD9970A28BF2E6233F3235233AA8D8", md5sum: "GFi9DSgcYPTdq9h7HCFKTw==",
           alt_name: "LINUX.X64_193000_db_home.zip", alt_sha256sum: "BA8329C757133DA313ED3B6D7F86C5AC42CD9970A28BF2E6233F3235233AA8D8", alt_md5sum: "GFi9DSgcYPTdq9h7HCFKTw==" }
@@ -221,6 +242,9 @@ rdbms_software:
     edition:
       - EE
       - SE2
+    os_version:
+      - 8
+      - 7
     files:
       - { name: "V978967-01.zip", sha256sum: "C96A4FD768787AF98272008833FE10B172691CF84E42816B138C12D4DE63AB96", md5sum: "mafEoIiopQLCYedBqDOa6A==" }
   - name: 12201_base
@@ -228,6 +252,9 @@ rdbms_software:
     edition:
       - EE
       - SE2
+    os_version:
+      - 8
+      - 7
     files:
       - { name: "V839960-01.zip", sha256sum: "96ED97D21F15C1AC0CCE3749DA6C3DAC7059BB60672D76B008103FC754D22DDE", md5sum: "GEHyzncJz5CdtMBk2AqueQ==" }
   - name: 12102_base
@@ -235,6 +262,7 @@ rdbms_software:
     edition:
       - EE
       - SE2
+    os_version: 7
     files:
       - { name: "{% if oracle_edition == 'SE2' %}V77388-01_1of2.zip{% else %}V46095-01_1of2.zip{% endif %}",
           sha256sum: "{% if oracle_edition == 'SE2' %}73873369753230F5A0921F95ACEADB591388CB06ED72A7F3AEA7BCBCEA2403BC{% else %}31FDC2AF41687B4E547A3A18F796424D8C1AF36406D2160F65B0AF6A9CD47355{% endif %}",
@@ -247,6 +275,7 @@ rdbms_software:
     edition:
       - EE
       - SE
+    os_version: 7
     files:
       - { name: "p13390677_112040_Linux-x86-64_1of7.zip", sha256sum: "0B399A6593804C04B4BD65F61E73575341A49F8A273ACABA0DCDA2DFEC4979E0", md5sum: "Fhb2F4mJGlbq/UDeefWPKA==" }
       - { name: "p13390677_112040_Linux-x86-64_2of7.zip", sha256sum: "73E04957EE0BF6F3B3E6CFCF659BDF647800FE52A377FB8521BA7E3105CCC8DD", md5sum: "Z7oeaKT1gbMFiFEUdoRD0w==" }

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -220,9 +220,6 @@ rdbms_software:
     edition:
       - EE
       - SE2
-    os_version:
-      - 8
-      - 7
     files:
       - { name: "V1011496-01.zip", sha256sum: "C05D5C32A72B9BF84AB6BABB49AEE99CBB403930406AABE3CF2F94F1D35E0916", md5sum: "iskVqACADd8Wo4JQbTlT2w==",
           alt_name: "LINUX.X64_213000_db_home.zip", alt_sha256sum: "C05D5C32A72B9BF84AB6BABB49AEE99CBB403930406AABE3CF2F94F1D35E0916", alt_md5sum: "iskVqACADd8Wo4JQbTlT2w==" }
@@ -231,9 +228,6 @@ rdbms_software:
     edition:
       - EE
       - SE2
-    os_version:
-      - 8
-      - 7
     files:
       - { name: "V982063-01.zip", sha256sum: "BA8329C757133DA313ED3B6D7F86C5AC42CD9970A28BF2E6233F3235233AA8D8", md5sum: "GFi9DSgcYPTdq9h7HCFKTw==",
           alt_name: "LINUX.X64_193000_db_home.zip", alt_sha256sum: "BA8329C757133DA313ED3B6D7F86C5AC42CD9970A28BF2E6233F3235233AA8D8", alt_md5sum: "GFi9DSgcYPTdq9h7HCFKTw==" }
@@ -242,9 +236,6 @@ rdbms_software:
     edition:
       - EE
       - SE2
-    os_version:
-      - 8
-      - 7
     files:
       - { name: "V978967-01.zip", sha256sum: "C96A4FD768787AF98272008833FE10B172691CF84E42816B138C12D4DE63AB96", md5sum: "mafEoIiopQLCYedBqDOa6A==" }
   - name: 12201_base
@@ -252,9 +243,6 @@ rdbms_software:
     edition:
       - EE
       - SE2
-    os_version:
-      - 8
-      - 7
     files:
       - { name: "V839960-01.zip", sha256sum: "96ED97D21F15C1AC0CCE3749DA6C3DAC7059BB60672D76B008103FC754D22DDE", md5sum: "GEHyzncJz5CdtMBk2AqueQ==" }
   - name: 12102_base
@@ -262,7 +250,6 @@ rdbms_software:
     edition:
       - EE
       - SE2
-    os_version: 7
     files:
       - { name: "{% if oracle_edition == 'SE2' %}V77388-01_1of2.zip{% else %}V46095-01_1of2.zip{% endif %}",
           sha256sum: "{% if oracle_edition == 'SE2' %}73873369753230F5A0921F95ACEADB591388CB06ED72A7F3AEA7BCBCEA2403BC{% else %}31FDC2AF41687B4E547A3A18F796424D8C1AF36406D2160F65B0AF6A9CD47355{% endif %}",
@@ -275,7 +262,6 @@ rdbms_software:
     edition:
       - EE
       - SE
-    os_version: 7
     files:
       - { name: "p13390677_112040_Linux-x86-64_1of7.zip", sha256sum: "0B399A6593804C04B4BD65F61E73575341A49F8A273ACABA0DCDA2DFEC4979E0", md5sum: "Fhb2F4mJGlbq/UDeefWPKA==" }
       - { name: "p13390677_112040_Linux-x86-64_2of7.zip", sha256sum: "73E04957EE0BF6F3B3E6CFCF659BDF647800FE52A377FB8521BA7E3105CCC8DD", md5sum: "Z7oeaKT1gbMFiFEUdoRD0w==" }

--- a/roles/rdbms-setup/tasks/main.yml
+++ b/roles/rdbms-setup/tasks/main.yml
@@ -41,26 +41,28 @@
   with_items: "{{ oracle_dirs + grid_dirs }}"
   tags: rdbms-setup,os-dirs
 
-- include_tasks: rdbms-install.yml
-  with_items: "{{ rdbms_software }}"
-  loop_control:
-    loop_var: osw
+- name: Determine required installation files
+  include_role:
+    name: swlib
+    tasks_from: build_file_list.yml
+  when: rdbms_base_files is not defined or rdbms_base_files | length == 0
+
+- name: Perform normal installation of RDBMS software
+  include_tasks: rdbms-install.yml
   when:
     - existing_dbhome.stdout == "0"
-    - osw.version == oracle_ver
-    - oracle_edition in osw.edition
     - not free_edition
+  vars:
+    osw: "{{ rdbms_base_files }}"
   tags: rdbms-setup
 
-- include_tasks: rdbms-rpm-install.yml
-  with_items: "{{ rdbms_software }}"
-  loop_control:
-    loop_var: osw
+- name: Perform RPM based installation
+  include_tasks: rdbms-rpm-install.yml
   when:
     - existing_dbhome.stdout == "0"
-    - osw.version == oracle_ver
-    - oracle_edition in osw.edition
     - free_edition
+  vars:
+    osw: "{{ rdbms_base_files }}"
   tags: rdbms-setup
 
 - name: Create sqlnet.ora file

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -22,7 +22,7 @@
 - name: rdbms-install | Installer confirmations
   debug:
     msg:
-      - "Installing from file(osw.files)          : {{ osw.files }}"
+      - "Installing from file(osw.name)           : {{ osw | map(attribute='name') | list }}"
       - "Unzipping into dir(install_unzip_path)   : {{ install_unzip_path }}"
       - "installer dir(runinstaller_loc)          : {{ runinstaller_loc }}"
       - "Src (swlib_path)                         : {{ swlib_path }}"
@@ -83,7 +83,7 @@
   become_user: "{{ oracle_user }}"
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: unzip -o -q "{{ swlib_path }}/{{ item.name }}" -d "{{ install_unzip_path }}"
-  with_items: "{{ osw.files }}"
+  with_items: "{{ osw }}"
   tags: rdbms-setup,sw-unzip
 
 - name: rdbms-install | Create RDBMS response file script

--- a/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-rpm-install.yml
@@ -19,6 +19,6 @@
     state: present
     lock_timeout: "{{ pkg_mgr_lock_timeout }}"
     disable_gpg_check: true
-  with_items: "{{ osw.files }}"
+  with_items: "{{ osw }}"
   register: rpm_install
   tags: rdbms-setup

--- a/roles/swlib/tasks/build_file_list.yml
+++ b/roles/swlib/tasks/build_file_list.yml
@@ -40,10 +40,19 @@
     - gi_install
     - patch_only is not defined
 
-- name: build_file_list | Build list of RDBMS base software by OS major version
+- name: build_file_list | Build list of RDBMS base software by valid OS major version
   set_fact:
-    rdbms_version_sw: "{{ (rdbms_software | selectattr('os_version', 'equalto', ansible_distribution_major_version ) | list)
-                        + (rdbms_software | selectattr('os_version', 'search', '\\b' + ansible_distribution_major_version  + '\\b') | list)
+    rdbms_version_sw: "{{ (rdbms_software | selectattr('os_version', 'undefined') | list)
+                        +
+                        (rdbms_software
+                        | selectattr('os_version', 'defined')
+                        | selectattr('os_version', 'equalto', ansible_distribution_major_version)
+                        | list)
+                        +
+                        (rdbms_software
+                        | selectattr('os_version', 'defined')
+                        | selectattr('os_version', 'search', '\\b' + ansible_distribution_major_version + '\\b')
+                        | list)
                        }}"
 
 - name: build_file_list | Refine list of RDBMS base software by edition

--- a/roles/swlib/tasks/build_file_list.yml
+++ b/roles/swlib/tasks/build_file_list.yml
@@ -40,10 +40,16 @@
     - gi_install
     - patch_only is not defined
 
-- name: build_file_list | Build list of RDBMS base software by edition
+- name: build_file_list | Build list of RDBMS base software by OS major version
   set_fact:
-    rdbms_edition_sw: "{{ (rdbms_software | selectattr('edition', 'equalto', oracle_edition) | list)
-                        + (rdbms_software | selectattr('edition', 'search', '\\b' + oracle_edition + '\\b') | list)
+    rdbms_version_sw: "{{ (rdbms_software | selectattr('os_version', 'equalto', ansible_distribution_major_version ) | list)
+                        + (rdbms_software | selectattr('os_version', 'search', '\\b' + ansible_distribution_major_version  + '\\b') | list)
+                       }}"
+
+- name: build_file_list | Refine list of RDBMS base software by edition
+  set_fact:
+    rdbms_edition_sw: "{{ (rdbms_version_sw | selectattr('edition', 'equalto', oracle_edition) | list)
+                        + (rdbms_version_sw | selectattr('edition', 'search', '\\b' + oracle_edition + '\\b') | list)
                        }}"
 
 - name: build_file_list | Build list of RDBMS base software
@@ -98,7 +104,7 @@
     - not gi_install
     - not free_edition
 
-- name: build_file_list | Display files lists
+- name: build_file_list | Display file lists
   debug:
     msg:
       opatch_file_list: "{{ opatch_file_list }}"


### PR DESCRIPTION
## Change Description:

Add support for installing Free edition on Enterprise Linux 9. And the dependent change of including an `os_version` key-value in the `rdbms_software` list of dicts to allow OS major version specific installations.

This is an **initial change** for allowing OS major version specific installations, with a focus on installing Free Edition on Enterprise Linux 9.

## Solution Overview:

Some installation media will be OS major version specific and other media will work with multiple OS versions. Consequently, a new `os_version` key-value that can either be a string value or a list is added to the `rdbms_software` list of dictionaries.

The `build_file_list.yml` task file now takes this into consideration when determining the required software to procure and install. (For Ansible 2.9 support, this must be done through a separate `set_fact` module task.)

Other aspects of OS major version an EL9 support **to come in complementary but separate and forthcoming PR** that will include:

- Changes required to **install 19c EE/SE2 on Enterprise Linux 9** (hence `rdbms_software` updates for non-Free edition currently do not list EL 9)
- Enhanced OS major version and other parameters compatibility checks

## Test Results:

Since the `rdbms_software` list is adjusted, tests to install Free edition on OL9 as well as to install EE against OL8 (a regression test essentially) were performed:

- [Free Edition installation using Oracle Linux 9](https://gist.github.com/simonpane/d562b157d94bd30e6278c710e65bd2c5)
- [19c EE installation using Oracle Linux 8](https://gist.github.com/simonpane/be09b6bebf3a30622635891846199a15)

Further, to ensure that the OS major version matched files were properly selected when installing 19c EE on OL8, added a dummy OL9 dict to `rdbms_software` to ensure that it was not used by the toolkit (this dummy entry was used during testing only and is not included in this PR):

```yaml
  - name: 19c_base
    version: 19.3.0.0.0
    edition:
      - EE
      - SE2
    os_version: 9
    files:
      - { name: "foobar.zip", sha256sum: "foobar", md5sum: "foobar==",
          alt_name: "foobar_db_home.zip", alt_sha256sum: "foobar", alt_md5sum: "foobar==" }
```