### PR TITLE
Override and set `ORA_DB_CONTAINER=TRUE` for Free edition installs

### DIFF
--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -893,6 +893,7 @@ if [ "${ORA_EDITION}" = "FREE" ]; then
   ORA_DB_NAME=FREE
   ORA_DISK_MGMT=FS
   ORA_ROLE_SEPARATION=FALSE
+  ORA_DB_CONTAINER=TRUE
   if [[ ! "${ORA_VERSION}" =~ ^23\. ]]; then
     ORA_VERSION="23.0.0.0.0"
   fi


### PR DESCRIPTION
Currently already setting some parameters to fixed values when the edition is "Free".  This change simply adds one more value to that section, essentially over-riding the user provided value.  The the goal of preventing the following error when `--ora-db-container False`:

```
["[FATAL] [DBT-10330] Container database (CDB) creation option is not selected.", "   CAUSE: You have specified the database template (FREE Database) which represents container database (CDB) information. But, you have not selected to create container database (CDB). Only container database (CDB) can be created using this template.", "   ACTION: Select container database (CDB) creation option. Alternatively specify different database template", "[FATAL] [DBT-10333] Container database (CDB) creation option is not selected.", "   CAUSE: Non-CDB creation is not supported.", "   ACTION: Make sure container database (CDB) option is selected."]
```

With the change in this PR, regardless of what the user provides for the `--ora-db-container` argument, the variable is over-ridden and set to `TRUE`.  As evident in the list of environment variables shown at the beginning of the script's STDOUT.

[Full test run using --ora-db-container=False](https://gist.github.com/simonpane/299b0e4281f41ac75c5397bcefbd923d)