### PR TITLE
set workload_agent_username conditionally

### DIFF
--- a/roles/workload-agent/defaults/main.yml
+++ b/roles/workload-agent/defaults/main.yml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 ---
-workload_agent_username: "wlmagent"
+workload_agent_username: "{{ 'c##wlmagent' if container_db else 'wlmagent' }}"


### PR DESCRIPTION
Set workload_agent_username conditionally based on the "container_db" flag: when container_db is true (Oracle Multitenant CDB), automatically prefix the username with "c##" to create a common user; when false, leave the username unchanged to create a local user. 


Test results:

https://gist.github.com/AlexBasinov/77f6073933f39cca361f4fd78a2758d4

Internal bug: b/441736294