### PR TITLE
Data Guard changes required to support deployments with XFS storage

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -20,7 +20,7 @@ oracle_ver_dir: "{% if free_edition %}{% if oracle_ver[:4] == '23.2' or oracle_v
 oracle_inventory: "{{ oracle_root }}/oraInventory"
 oracle_base: "{% if free_edition %}/opt/oracle{% else %}{{ oracle_root }}/oracle{% endif %}"
 oracle_home: "{{ oracle_base }}/product/{{ oracle_ver_dir }}/{{ home_name }}"
-grid_home: "{{ oracle_root }}/{{ oracle_ver_dir }}/grid"
+grid_home: "{% if role_separation %}{{ oracle_root }}/{{ oracle_ver_dir }}/grid{% else %}{{ oracle_home }}{% endif %}"
 grid_base: "{{ oracle_root }}/grid"
 
 path_udev: asmdisks

--- a/roles/db-adjustments/defaults/main.yml
+++ b/roles/db-adjustments/defaults/main.yml
@@ -13,6 +13,4 @@
 # limitations under the License.
 
 ---
-db_script_files:
-  - archivelog_mode.sh
-  - db_modifications.sh
+db_script_files: "{{ (['archivelog_mode.sh'] if not standby_setup | default(False) else []) + ['db_modifications.sh'] }}"

--- a/roles/db-adjustments/templates/archivelog_mode.sh.j2
+++ b/roles/db-adjustments/templates/archivelog_mode.sh.j2
@@ -10,6 +10,7 @@ fi
 
 sqlplus -s -L / as sysdba <<EOF
 whenever sqlerror exit failure
+
 startup mount
 alter database archivelog;
 alter database open;
@@ -18,18 +19,12 @@ archive log list
 set pages 32767 lines 180 trims on tab off
 column name format a32
 column display_value format a64
-column status format a32
-column filename format a64
 
-alter database enable block change tracking;
-select status, filename from v\$block_change_tracking;
+select name, display_value
+  from v\$system_parameter2
+ where (name like 'log_archive%' and isdefault != 'TRUE') or name like 'db_recovery%'
+ order by 1,2;
 
-select name, display_value from (
-select name, display_value from v\$system_parameter2 where name like 'log_archive%' and isdefault != 'TRUE'
-union
-select name, display_value from v\$system_parameter2 where name like 'db_recovery%'
-)
-order by 1,2;
 EOF
 
 {% if groups['dbasm'] | length > 1 %}

--- a/roles/db-adjustments/templates/db_modifications.sh.j2
+++ b/roles/db-adjustments/templates/db_modifications.sh.j2
@@ -2,12 +2,26 @@ source oraenv <<< {{ oracle_sid }}
 
 sqlplus -s -L / as sysdba <<EOF
 whenever sqlerror exit failure
+
 set pages 32767 lines 180 trims on tab off
 set serverout on
+
 column name format a32
 column display_value format a64
+column status format a32
+column filename format a64
 
 alter database add supplemental log data;
+
+DECLARE
+   v_bct_status VARCHAR2(10);
+BEGIN
+   SELECT status INTO v_bct_status FROM v\$block_change_tracking;
+   IF v_bct_status = 'DISABLED' THEN
+      EXECUTE IMMEDIATE 'alter database enable block change tracking';
+   END IF;
+END;
+/
 
 DECLARE
    v_force_logging_status VARCHAR2(3);
@@ -37,6 +51,8 @@ BEGIN
 END;
 /
 
+select status, filename from v\$block_change_tracking;
 select name, db_unique_name, force_logging, supplemental_log_data_min, flashback_on from v\$database;
 select name, display_value from v\$system_parameter2 where name like '%flashback%';
+
 EOF

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -69,8 +69,8 @@
     - name: Active-copy | Manually add tnsnames.ora entry for automatic service registration (with GI)
       lineinfile:
         path: "{{ oracle_home }}/network/admin/tnsnames.ora"
-        regexp: "^LISTENER_{{ db_name }}"
-        line: "LISTENER_{{ db_name }} = (ADDRESS = (PROTOCOL = IPC)(HOST = {{ ansible_hostname }})(KEY = LISTENER))"
+        regexp: "^LISTENER_{{ oracle_sid | upper }}"
+        line: "LISTENER_{{ oracle_sid | upper }} = (ADDRESS = (PROTOCOL = IPC)(HOST = {{ ansible_hostname }})(KEY = LISTENER))"
         create: true
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
@@ -82,8 +82,8 @@
     - name: Active-copy | Manually add tnsnames.ora entry for automatic service registration (no GI)
       lineinfile:
         path: "{{ oracle_home }}/network/admin/tnsnames.ora"
-        regexp: "^LISTENER_{{ db_name }}"
-        line: "LISTENER_{{ db_name }} = (ADDRESS = (PROTOCOL = TCP)(HOST = {{ ansible_hostname }})(PORT = {{ listener_port }}))"
+        regexp: "^LISTENER_{{ oracle_sid | upper }}"
+        line: "LISTENER_{{ oracle_sid | upper }} = (ADDRESS = (PROTOCOL = TCP)(HOST = {{ ansible_hostname }})(PORT = {{ listener_port }}))"
         create: true
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -15,7 +15,12 @@
 ---
 - name: Active-copy | Check if the standby database is already running
   shell: |
-    srvctl status database -d {{ standby_name }} || true
+    set -o pipefail
+    if srvctl config db -d {{ standby_name }} >/dev/null 2>&1; then
+      srvctl status database -d {{ standby_name }} || true
+    else
+      ps -ef | grep [o]ra_pmon_{{ oracle_sid }} > /dev/null && echo "{{ oracle_sid }} is running" || true
+    fi
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
@@ -61,7 +66,7 @@
       become_user: "{{ grid_user }}"
       when: primary_listener_update is defined and primary_listener_update.changed
 
-    - name: Active-copy | Manually add tnsnames.ora entry for automatic service registration
+    - name: Active-copy | Manually add tnsnames.ora entry for automatic service registration (with GI)
       lineinfile:
         path: "{{ oracle_home }}/network/admin/tnsnames.ora"
         regexp: "^LISTENER_{{ db_name }}"
@@ -70,6 +75,20 @@
         owner: "{{ oracle_user }}"
         group: "{{ oracle_group }}"
         mode: u=rw,g=r,o=
+      when: gi_install
+      become: true
+      become_user: "{{ oracle_user }}"
+
+    - name: Active-copy | Manually add tnsnames.ora entry for automatic service registration (no GI)
+      lineinfile:
+        path: "{{ oracle_home }}/network/admin/tnsnames.ora"
+        regexp: "^LISTENER_{{ db_name }}"
+        line: "LISTENER_{{ db_name }} = (ADDRESS = (PROTOCOL = TCP)(HOST = {{ ansible_hostname }})(PORT = {{ listener_port }}))"
+        create: true
+        owner: "{{ oracle_user }}"
+        group: "{{ oracle_group }}"
+        mode: u=rw,g=r,o=
+      when: not gi_install
       become: true
       become_user: "{{ oracle_user }}"
 
@@ -134,7 +153,7 @@
     - name: Active-copy | Get the primary database password file information
       shell: |
         set -o pipefail
-        (srvctl config db -d {{ db_name }} || true) | grep "^Password file"
+        (srvctl config db -d {{ db_name }} || true) | grep "^Password file" || true
       environment:
         ORACLE_HOME: "{{ oracle_home }}"
         ORACLE_SID: "{{ oracle_sid }}"
@@ -215,6 +234,7 @@
           - "file={{ password_file_name }}"
           - "force=y"
           - "password={{ sys_pass }}"
+          - "format=12"
       environment:
         ORACLE_HOME: "{{ oracle_home }}"
         ORACLE_SID: "{{ oracle_sid }}"
@@ -313,12 +333,15 @@
         ORACLE_HOME: "{{ oracle_home }}"
         ORACLE_SID: "{{ oracle_sid }}"
         PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      when: gi_install
       become: true
       become_user: "{{ oracle_user }}"
 
     - name: Active-copy | Run tasks from the database adjustments role
       include_role:
         name: db-adjustments
+      vars:
+        standby_setup: true
 
     - name: Active-copy | Move spfile into ASM and restart
       shell: |
@@ -335,6 +358,7 @@
         ORACLE_HOME: "{{ oracle_home }}"
         ORACLE_SID: "{{ oracle_sid }}"
         PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+      when: gi_install
       become: true
       become_user: "{{ oracle_user }}"
 
@@ -356,6 +380,26 @@
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when: gi_install
+  become: true
+  become_user: "{{ oracle_user }}"
+  changed_when: false
+  register: standby_state
+  tags: active-duplicate
+
+- name: Active-copy | Capture standby database state
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s -L / as sysdba <<EOF
+    whenever sqlerror exit failure
+    SET lines 120 tab OFF trims ON
+    SELECT db_unique_name, database_role, open_mode, switchover_status FROM v\$database;
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when: not gi_install
   become: true
   become_user: "{{ oracle_user }}"
   changed_when: false

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -142,7 +142,7 @@
 
         - name: DG | Fetch password file from primary
           fetch:
-            src: "{{ oracle_base }}/dbs/orapwORCL"
+            src: "{{ oracle_base }}/dbs/orapw{{ oracle_sid }}"
             dest: "{{ temp_file.path }}"
             flat: true
           delegate_to: primary1
@@ -150,7 +150,7 @@
         - name: DG | Copy password file to standby
           copy:
             src: "{{ temp_file.path }}"
-            dest: "{{ oracle_base }}/dbs/orapwORCL"
+            dest: "{{ oracle_base }}/dbs/orapw{{ oracle_sid }}"
             owner: "{{ oracle_user }}"
             group: "{{ oracle_group }}"
             mode: "u=wr,go="


### PR DESCRIPTION
## Change Description:

Changes required to allow Data Guard deployments for databases using XFS storage (without Grid Infrastructure / clusterware)

## Solution Overview:

Small amount of changes to Data Guard tasks required to add compatibility with deployments using XFS file systems.

Including changes to the `db-adjustments` role templates files to:

- Only put the database into archivelog mode if role is not run during a standby setup.  As with clusterware managed environments, restart will return the database to the MOUNT state.  But with non-clusterware managed databases, it will open the database on startup.  After the RMAN duplicate command, the standby database is already in archivelog mode.
- Moved the other step of enabling block change tracking from the `archivelog_mode.sh.j2` template to the more suitable `db_modifications.sh.j2` template which is run for every database creation regardless of whether a primary or standby.
- Added PL/SQL block so that BCT is only enabled if required, preventing unnecessary ORA- errors that would cause script failure due to `whenever sqlerror exit failure` clause.

## Test Results:

- [Oracle 19c EE Data Guard deployment with XFS storage](https://gist.github.com/simonpane/059793c7fffe7e9e92d95e68a4edce1a) 

> **NOTE:** In output log the ` Validating static connect identifier for the primary database orcl... ORA-01017: invalid username/password; logon denied` message is somewhat expected as a dgmgrl connect using a password is required to properly test the static connect identifiers.