### PR TITLE
Add role to validate minimum free disk space before installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ secrets.yml
 secrets/
 terraform/*sh-key*
 vars/
+!roles/*/vars/
 vault_password_file
 terraform/terraform.tfvars
+roles/disk_space_check/molecule/*
+roles/disk_space_check/molecule/

--- a/config-rac-db.yml
+++ b/config-rac-db.yml
@@ -29,6 +29,21 @@
 
 - hosts: dbasm[0]
   tasks:
+    # Ensure common defaults are present when included via include_role (Ansible 2.9)
+    - name: Load common defaults (fallback)
+      include_vars:
+        dir: "roles/common/defaults"
+      when:
+        - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+      tags: rac-db
+
+    - name: Perform disk space checks for RAC database
+      include_role:
+        name: disk_space_check
+      vars:
+        disk_check_type: rac
+      tags: rac-db,disk_space_check
+    
     - include_role:
         name: db-create
         tasks_from: rac-db-create.yml

--- a/roles/db-create/tasks/main.yml
+++ b/roles/db-create/tasks/main.yml
@@ -13,6 +13,23 @@
 # limitations under the License.
 
 ---
+
+# Ensure common defaults are present when included via include_role (Ansible 2.9)
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: db-create
+
+# Check disk space before creating database
+- name: db-create | Validate disk space for database creation
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_type: db
+  tags: disk_space_check,db-create
+
 - name: Test whether pmon process by same name already exists
   shell: "set -o pipefail; ps -ef | ( grep pmon || true ) | ( grep -i {{ db_name }} || true ) | ( grep -v grep || true ) | wc -l"
   changed_when: false

--- a/roles/disk_space_check/defaults/main.yml
+++ b/roles/disk_space_check/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# Simplified defaults for disk space checking
+
+# Core behavior controls
+disk_space_fail_on_insufficient: true
+disk_space_warning_threshold_percent: 80
+disk_space_critical_threshold_percent: 90
+disk_space_show_warnings: true
+
+# Default space requirements (MB) - organized by component
+disk_space_defaults:
+  oracle:
+    home: 10240 # 10GB
+    base: 5120 # 5GB
+    swlib: 19883 # 20GB
+    unzip: 10240 # 10GB
+  gi:
+    home: 15360 # 15GB
+    base: 5120 # 5GB
+    unzip: 10240 # 10GB
+  rac:
+    grid: 20480 # 20GB
+    oracle: 15360 # 15GB
+    unzip: 15360 # 15GB
+  patch:
+    home: 5120 # 5GB
+    extract: 10240 # 10GB
+    temp: 2048 # 2GB
+  db:
+    data: 20480 # 20GB
+    recovery: 10240 # 10GB
+    config: 512 # 512MB

--- a/roles/disk_space_check/tasks/check_path.yml
+++ b/roles/disk_space_check/tasks/check_path.yml
@@ -1,0 +1,104 @@
+---
+# Disk space validation for a specific path with proper delegation support
+- name: Gather filesystem facts on target host
+  setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - "mounts"
+  delegate_to: "{{ disk_check_host | default(inventory_hostname) }}"
+  delegate_facts: true
+  tags: disk_space_check
+
+- name: Get mounts from target host
+  set_fact:
+    target_host: "{{ disk_check_host | default(inventory_hostname) }}"
+    host_mounts: "{{ hostvars[disk_check_host | default(inventory_hostname)].ansible_mounts | default([]) }}"
+  tags: disk_space_check
+
+- name: Initialize mount tracking
+  set_fact:
+    target_mount: null
+    target_mount_len: 0
+  tags: disk_space_check
+
+- name: Find best matching mount point (longest prefix match)
+  set_fact:
+    target_mount: "{{ item }}"
+    target_mount_len: "{{ item.mount | length }}"
+  loop: "{{ host_mounts }}"
+  when:
+    - (check_path | string).startswith(item.mount | string)
+    - (item.mount | length) > (target_mount_len | int)
+  tags: disk_space_check
+
+- name: Fail if no mount found
+  fail:
+    msg: "No mounted filesystem found for path {{ check_path }} on {{ target_host }}"
+  when: target_mount is none or target_mount is not defined
+  tags: disk_space_check
+
+- name: Calculate available space
+  set_fact:
+    available_mb: "{{ ((target_mount.size_available | default(0) | int) / 1048576) | int }}"
+    required_mb: "{{ required_mb | default(0) | int }}"
+    mount_point: "{{ target_mount.mount }}"
+    used_percent: "{{ (100 - ((target_mount.size_available | default(0) | float) / (target_mount.size_total | default(1) | float) * 100)) | int }}"
+    # Pre-calculate shortfall as integer to avoid type issues
+    shortfall_mb: "{{ ( (required_mb | default(0) | int) - ( ((target_mount.size_available | default(0) | int) / 1048576) | int ) ) }}"
+  changed_when: false
+  tags: disk_space_check
+
+- name: Display disk space check details (diagnostic)
+  debug:
+    msg:
+      - "Checking: {{ check_description }}"
+      - "Path: {{ check_path }}"
+      - "Mount: {{ mount_point }}"
+      - "Required: {{ required_mb }} MB"
+      - "Available: {{ available_mb }} MB"
+      - "Used: {{ used_percent }}%"
+      - "Status: {{ 'PASS' if (available_mb | int) >= (required_mb | int) else 'FAIL' }}"
+    verbosity: 1
+  when: 
+    - disk_space_show_warnings | default(true) | bool
+    - (available_mb | int) >= (required_mb | int)  # Only show diagnostic info on success
+  tags: disk_space_check
+
+- name: Display disk space failure warning
+  debug:
+    msg:
+      - "WARNING: Insufficient disk space for {{ check_description }}"
+      - "Path: {{ check_path }} (Mount: {{ mount_point }})"
+      - "Required: {{ required_mb }} MB, Available: {{ available_mb }} MB"
+      - "Shortfall: {{ [((required_mb | int) - (available_mb | int)), 0] | max }} MB"
+    verbosity: 0
+  when: 
+    - disk_space_show_warnings | default(true) | bool
+    - (available_mb | int) < (required_mb | int)
+    - not (disk_space_fail_on_insufficient | default(true) | bool)  # Only warn if not failing
+  tags: disk_space_check
+
+- name: Assert sufficient disk space
+  assert:
+    that:
+      - (available_mb | int) >= (required_mb | int)
+    fail_msg: |
+      Insufficient disk space for {{ check_description }}
+      Path: {{ check_path }}
+      Mount: {{ mount_point }}
+      Required: {{ required_mb }} MB
+      Available: {{ available_mb }} MB
+      Shortfall: {{ [shortfall_mb | int, 0] | max }} MB
+    success_msg: "Sufficient disk space for {{ check_description }} ({{ available_mb }} MB available)"
+  when: disk_space_fail_on_insufficient | default(true) | bool
+  tags: disk_space_check
+
+- name: Warn on high usage
+  debug:
+    msg: "WARNING: Mount {{ mount_point }} is {{ used_percent }}% full (threshold: {{ disk_space_warning_threshold_percent | default(80) }}%)"
+    verbosity: 0
+  when:
+    - (used_percent | int) >= (disk_space_warning_threshold_percent | default(80) | int)
+    - disk_space_show_warnings | default(true) | bool
+  tags: disk_space_check

--- a/roles/disk_space_check/tasks/main.yml
+++ b/roles/disk_space_check/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+# Disk space check role - main orchestration
+
+# Load common role defaults as a fallback (handles include_role without meta deps on 2.9)
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: disk_space_check
+
+# Load disk space requirements from vars directory
+- name: Load disk space requirements
+  include_vars: "{{ role_path }}/vars/requirements.yml"
+  when: disk_space_requirements is not defined
+  tags: disk_space_check
+
+- name: Validate required variables for check type
+  assert:
+    that:
+      - oracle_ver is defined
+      - (disk_check_type != 'oracle_home') or (oracle_home is defined and oracle_base is defined)
+      - (disk_check_type != 'gi') or (grid_home is defined and oracle_base is defined)
+      - (disk_check_type != 'rac') or (grid_home is defined and oracle_home is defined)
+      - (disk_check_type != 'patch') or (grid_home is defined or oracle_home is defined)
+      - (disk_check_type != 'db') or ((ora_disk_management | default('fs') | lower) != 'fs') or (oracle_home is defined)
+    fail_msg: >-
+      Missing required variables for disk_check_type {{ disk_check_type }}. Ensure 'common' defaults are loaded
+      (role dependency) or include roles/common/defaults via include_vars.
+  when:
+    - disk_check_type is defined
+    - disk_check_type in ['oracle_home', 'gi', 'rac', 'patch', 'db']
+  tags: disk_space_check
+
+- name: Validate disk space for component
+  include_tasks: check_path.yml
+  vars:
+    check_path: "{{ requirement.path }}"
+    required_mb: "{{ requirement.mb }}"
+    check_description: "{{ requirement.desc }}"
+  loop: "{{ disk_space_requirements[disk_check_type] | default([]) }}"
+  loop_control:
+    loop_var: requirement
+  when:
+    - disk_check_type is defined
+    - disk_space_requirements is defined
+    - disk_space_requirements[disk_check_type] is defined
+    - (disk_check_type != 'db') or ((ora_disk_management | default('fs') | lower) == 'fs')
+    - (disk_check_type != 'db') or (oracle_home is defined)
+    - requirement.when | default(true) | bool
+  tags: disk_space_check
+
+- name: Validate specific path if provided
+  include_tasks: check_path.yml
+  vars:
+    check_path: "{{ disk_check_path }}"
+    required_mb: "{{ disk_check_required_mb | default(disk_space_minimum_mb | default(1024)) }}"
+    check_description: "{{ disk_check_description | default('custom path') }}"
+  when:
+    - disk_check_path is defined
+    - disk_check_type is not defined
+  tags: disk_space_check

--- a/roles/disk_space_check/vars/requirements.yml
+++ b/roles/disk_space_check/vars/requirements.yml
@@ -1,0 +1,70 @@
+---
+# Consolidated disk space requirements for all Oracle components
+# Uses safe concatenation and defaults to avoid undefined variable errors
+disk_space_requirements:
+  # Oracle RDBMS installation
+  oracle_home:
+    - path: "{{ oracle_home }}"
+      mb: "{{ disk_space_oracle_home_mb | default(disk_space_defaults.oracle.home) }}"
+      desc: "Oracle Home"
+    - path: "{{ oracle_base }}"
+      mb: "{{ disk_space_oracle_base_mb | default(disk_space_defaults.oracle.base) }}"
+      desc: "Oracle Base"
+  
+  # Software library staging
+  swlib:
+    - path: "{{ swlib_path }}"
+      mb: "{{ disk_space_swlib_mb | default(disk_space_defaults.oracle.swlib) }}"
+      desc: "Software library"
+    - path: "{{ swlib_unzip_path }}"
+      mb: "{{ disk_space_unzip_mb | default(disk_space_defaults.oracle.unzip) }}"
+      desc: "Software extraction"
+  
+  # Patching operations
+  patch:
+    - path: "{{ grid_home if gi_install else oracle_home }}"
+      mb: "{{ disk_space_patch_home_mb | default(disk_space_defaults.patch.home) }}"
+      desc: "Patch target"
+    - path: "{{ swlib_unzip_path }}"
+      mb: "{{ disk_space_patch_extract_mb | default(disk_space_defaults.patch.extract) }}"
+      desc: "Patch extraction"
+    - path: "/tmp"
+      mb: "{{ disk_space_patch_temp_mb | default(disk_space_defaults.patch.temp) }}"
+      desc: "Patch temporary space"
+  
+  # Grid Infrastructure
+  gi:
+    - path: "{{ grid_home }}"
+      mb: "{{ disk_space_gi_home_mb | default(disk_space_defaults.gi.home) }}"
+      desc: "Grid Infrastructure Home"
+    - path: "{{ oracle_base }}"
+      mb: "{{ disk_space_gi_base_mb | default(disk_space_defaults.gi.base) }}"
+      desc: "GI Oracle Base"
+    - path: "{{ swlib_unzip_path }}"
+      mb: "{{ disk_space_gi_unzip_mb | default(disk_space_defaults.gi.unzip) }}"
+      desc: "GI extraction"
+  
+  # RAC installation
+  rac:
+    - path: "{{ grid_home }}"
+      mb: "{{ disk_space_rac_grid_mb | default(disk_space_defaults.rac.grid) }}"
+      desc: "RAC Grid Home"
+    - path: "{{ oracle_home }}"
+      mb: "{{ disk_space_rac_oracle_mb | default(disk_space_defaults.rac.oracle) }}"
+      desc: "RAC Database Home"
+    - path: "{{ swlib_unzip_path }}"
+      mb: "{{ disk_space_rac_unzip_mb | default(disk_space_defaults.rac.unzip) }}"
+      desc: "RAC extraction"
+  
+  # Database creation
+  db:
+    - path: "{{ data_destination }}"
+      mb: "{{ disk_space_db_data_mb | default(disk_space_defaults.db.data) }}"
+      desc: "Database datafiles"
+    - path: "{{ reco_destination }}"
+      mb: "{{ disk_space_db_recovery_mb | default(disk_space_defaults.db.recovery) }}"
+      desc: "Fast Recovery Area"
+    - path: "{{ oracle_home }}/dbs"
+      mb: "{{ disk_space_db_config_mb | default(disk_space_defaults.db.config) }}"
+      desc: "Database config files"
+      # Always a filesystem path under ORACLE_HOME

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 ---
+# Ensure common defaults are present when included via include_role (Ansible 2.9)
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: gi-setup
+
 - name: gi-install | Set facts
   set_fact:
     install_unzip_path: "{{ grid_home }}"
@@ -37,6 +45,16 @@
     verbosity: 0
   tags: gi-setup
 
+- name: gi-install | Check disk space before patch extraction
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_path: "{{ swlib_unzip_path }}"
+    disk_check_required_mb: "{{ disk_space_defaults.gi.unzip }}"
+    disk_check_description: "Space for GI patch extraction"
+  when: gi_patches is defined and gi_patches | length > 0
+  tags: gi-setup,disk_space_check
+
 - name: gi-install | Unzip GI patch
   # Using the "shell" module instead of "unarchive" for unzip performance
   shell: |
@@ -55,6 +73,15 @@
   with_items: "{{ gi_patches }}"
   when: item.release == oracle_rel and item.category == 'RU'
   tags: gi-setup,rel-patch
+
+- name: gi-install | Check disk space before GI software extraction
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_path: "{{ install_unzip_path }}"
+    disk_check_required_mb: "{{ disk_space_defaults.gi.home }}"
+    disk_check_description: "Space for GI software extraction"
+  tags: gi-setup,disk_space_check
 
 - name: gi-install | Unzipping GI software
   become: true

--- a/roles/gi-setup/tasks/main.yml
+++ b/roles/gi-setup/tasks/main.yml
@@ -13,8 +13,23 @@
 # limitations under the License.
 
 ---
+
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: gi-setup
+
+- name: Perform disk space checks for Grid Infrastructure
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_type: gi
+  tags: gi-setup,disk_space_check
+
 - name: Check if software is already installed
-  shell: cat "{{ oracle_inventory }}/ContentsXML/inventory.xml" 2>&1 | ( grep -w {{ grid_home }} || true ) | wc -l
+  shell: 'set -o pipefail; cat "{{ oracle_inventory }}/ContentsXML/inventory.xml" 2>&1 | ( grep -w {{ grid_home }} || true ) | wc -l'
   register: existing_dbhome
   become: true
   become_user: root

--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -13,6 +13,22 @@
 # limitations under the License.
 
 ---
+
+# Ensure common defaults are present when included via include_role (Ansible 2.9)
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+
+# Check disk space before applying patches
+- name: patch | Validate disk space for patching operations
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_type: patch
+  tags: disk_space_check,patch
+
 - name: Create OCM response file
   script: expect_rsp.sh {{ oracle_base }} {{ oracle_home }} {{ swlib_unzip_path }}
   args:

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -13,6 +13,21 @@
 # limitations under the License.
 
 ---
+
+- name: rac-gi-install | Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: rac-gi
+
+- name: rac-gi-install | Perform disk space checks for RAC Grid Infrastructure
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_type: rac
+  tags: rac-gi,disk_space_check
+
 - name: rac-gi-install | Set facts
   set_fact:
     install_unzip_path: "{{ grid_home }}"
@@ -27,6 +42,16 @@
       - "Using cluvfy cmd     : {{ cluvfy_command }}"
     verbosity: 0
   tags: rac-gi
+
+- name: rac-gi-install | Check disk space before patch extraction
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_path: "{{ swlib_unzip_path }}"
+    disk_check_required_mb: "{{ disk_space_defaults.rac.unzip }}"
+    disk_check_description: "Space for RAC GI patch extraction"
+  when: gi_patches is defined and gi_patches | length > 0
+  tags: rac-gi,disk_space_check
 
 - name: rac-gi-install | Unzip GI patch
   # Using the "shell" module instead of "unarchive" for unzip performance

--- a/roles/rdbms-setup/tasks/main.yml
+++ b/roles/rdbms-setup/tasks/main.yml
@@ -13,6 +13,23 @@
 # limitations under the License.
 
 ---
+
+# Ensure common defaults are present when included via include_role (Ansible 2.9)
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: rdbms-setup
+
+# Check disk space before Oracle RDBMS installation
+- name: rdbms-setup | Validate disk space requirements
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_type: oracle_home
+  tags: disk_space_check,rdbms-setup
+
 - name: Check if software is already installed
   shell: cat "{{ oracle_inventory }}/ContentsXML/inventory.xml" 2>&1 | ( grep -w {{ oracle_home }} || true ) | wc -l
   register: existing_dbhome

--- a/roles/swlib/tasks/main.yml
+++ b/roles/swlib/tasks/main.yml
@@ -13,6 +13,22 @@
 # limitations under the License.
 
 ---
+# Ensure common defaults are present when included via include_role (Ansible 2.9)
+- name: Load common defaults (fallback)
+  include_vars:
+    dir: "{{ role_path }}/../common/defaults"
+  when:
+    - oracle_base is not defined or oracle_home is not defined or grid_home is not defined
+  tags: swlib
+
+# Check disk space before creating software library
+- name: swlib | Check disk space requirements
+  include_role:
+    name: disk_space_check
+  vars:
+    disk_check_type: swlib
+  tags: disk_space_check
+
 - name: swlib | setup
   become: true
   become_user: root


### PR DESCRIPTION
 Change Description:

  - Implemented centralized disk space validation and integrated pre-flight checks across software staging, patching, installation, and database creation to fail fast with clear diagnostics instead of proceeding to partial or corrupt operations.
  - Added a reusable role (roles/disk_space_check) and wired it into swlib, patch, rdbms-setup, gi-setup, rac-gi-setup, and db-create. Added Ansible 2.9-safe include_vars fallbacks where needed and updated config-rac-db.yml to run readiness checks and a RAC
  disk-space pre-check. Extended .gitignore for disk-space role Molecule paths.

  Solution Overview:

  - Central role: disk_space_check
      - Configurable thresholds per operation in roles/disk_space_check/defaults/main.yml, overridable via vars (MB).
      - Mount-aware checks: gathers mounts, finds the best matching mount (longest prefix) for each path, and supports delegation via disk_check_host.
      - Clear assert-based failures showing required, available, and shortfall; high-usage warnings via disk_space_warning_threshold_percent (default 80%). Can be switched to warn-only via disk_space_fail_on_insufficient: false.
      - Supported types: swlib, oracle_home, gi, rac, patch, db (DB checks run only when ora_disk_management == 'fs').
  - Role integrations
      - swlib: pre-checks swlib_path and swlib_unzip_path capacity (via disk_check_type: swlib).
      - patch: pre-checks patch target home, extraction path, and /tmp (via disk_check_type: patch).
      - rdbms-setup: pre-checks Oracle Home/Base space (via disk_check_type: oracle_home).
      - gi-setup: pre-checks GI requirements (via disk_check_type: gi), plus explicit checks for GI patch extraction and GI software extraction paths.
      - rac-gi-setup: pre-checks RAC GI requirements (via disk_check_type: rac), plus RAC GI patch extraction path checks.
      - db-create: pre-checks data, recovery, and config paths for filesystem-managed deployments (skips when ASM/ASMLib).
  - Default thresholds (overridable):
      - oracle: home 10GB, base 5GB, swlib 20GB, unzip 10GB
      - gi: home 15GB, base 5GB, unzip 10GB
      - rac: grid 20GB, oracle 15GB, unzip 15GB
      - patch: home 5GB, extract 10GB, temp 2GB
      - db: data 20GB, recovery 10GB, config 512MB

 - Ansible 2.9 note: Dynamic role includes (include_role/import_role) do not honor role dependencies declared in meta/main.yml; dependencies are only applied when roles are listed under the play-level roles: key. Because several roles are included dynamically
  and expect baseline variables from the common role, we added a conditional fallback that loads roles/common/defaults via include_vars if oracle_base/oracle_home/grid_home are not defined. This prevents undefined-variable errors while remaining a no-op when
  those vars are already set by inventories, group_vars, or earlier roles. See Ansible 2.9 docs on role dependencies and include_role behavior: role dependencies, include_role, import_role, variable precedence, include_vars.

▌Can you please help me