### PR TITLE
Address host-storage warnings for filesystem installs

### DIFF
--- a/roles/host-storage/tasks/main.yml
+++ b/roles/host-storage/tasks/main.yml
@@ -65,18 +65,11 @@
   with_items: "{{ oracle_user_data_mounts }}"
   tags: ora-mounts
 
-- name: This iteration to get all blk_devices regardless of their diskgroup - used for partitioning all asm disks
-  debug:
-    msg: "Running parted {{ item.1.blk_device }}"
-    verbosity: 1
-  with_subelements:
-    - "{{ asm_disks }}"
-    - disks
-
 - name: This iteration to create asm disks with their asm name and block_device
   debug:
     msg: "Running create asmdisk {{ item.1.name }} with disk {{ item.1.blk_device }}"
     verbosity: 1
+  when: gi_install
   with_subelements:
     - "{{ asm_disks }}"
     - disks
@@ -91,4 +84,5 @@
          'compatible.asm'   = '"${ORACLE_VERSION}"',
          'compatible.rdbms' = '11.2.0.4.0';
     verbosity: 1
+  when: gi_install
   with_items: "{{ asm_disks }}"


### PR DESCRIPTION
Filesystem installs produce a series of warnings:

```
2025-09-12 19:17:02     [WARNING]: Unable to find 'asm_disk_config.json' in expected paths (use -vvvvv
2025-09-12 19:17:02     to see paths)
2025-09-12 19:17:02     [WARNING]: Unable to find 'asm_disk_config.json' in expected paths (use -vvvvv
2025-09-12 19:17:02     to see paths)
2025-09-12 19:17:02     [WARNING]: Unable to find 'asm_disk_config.json' in expected paths (use -vvvvv
2025-09-12 19:17:02     to see paths)
```

A debug run confirms that they're coming from the `host-storage` playbook, and looking at the tasks, it's pretty obvious:  they have `with_subelements` of `{{ asm_disks }}`.  And `{{ asm_disks }}` isn't defined for FS installs.

This change simply makes them conditional.  Only ASM installs need to run CREATE DISKGROUP.

Furthermore, there is a task to do a debug print about running parted, even though the actual task to run parted no longer exists.  Removing the debug print.