### PR TITLE
Remove DB name from data/reco directories

### DIFF
--- a/roles/common/defaults/main/base_variables.yml
+++ b/roles/common/defaults/main/base_variables.yml
@@ -120,11 +120,11 @@ grid_dirs:
     mode: "ug=rwx,o=rx"
 
 fs_dirs:
-  - name: "{{ data_destination }}/{{ db_name }}"
+  - name: "{{ data_destination }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: "u=rwx,g=rx,o="
-  - name: "{{ reco_destination }}/{{ db_name }}"
+  - name: "{{ reco_destination }}"
     owner: "{{ oracle_user }}"
     group: "{{ oracle_group }}"
     mode: "u=rwx,g=rx,o="


### PR DESCRIPTION
For filesystem installs, we create a directory owned by {{ oracle_user }}, on both data and reco destinations, so put the database itself on.  We name is after the {{ db_name }}, under the appropriate destination.

But I've observed that, with Oracle 19c, if I use a lowercase database name, DBCA creates a directory with the uppercase name, and fails on file creation:

```
[Thread-268] [ 2025-09-12 19:37:07.102 UTC ] [RMANEngine.readSqlOutput:997]  Log RMAN Output=RMAN-03002: failure of restore command at 09/12/2025 19:37:07
[Thread-268] [ 2025-09-12 19:37:07.102 UTC ] [RMANEngine.readSqlOutput:997]  Log RMAN Output=ORA-01264: Unable to create datafile file name
[Thread-268] [ 2025-09-12 19:37:07.102 UTC ] [RMANEngine.readSqlOutput:997]  Log RMAN Output=ORA-19800: Unable to initialize Oracle Managed Destination
[Thread-268] [ 2025-09-12 19:37:07.102 UTC ] [RMANEngine.readSqlOutput:997]  Log RMAN Output=Linux-x86_64 Error: 13: Permission denied
```

This change removes the {{ db_name }} from the directory, effectively allowing the oracle user to write to anywhere in the {{ data_destination }} or {{ reco_destination }}

An example, on an installed and running database:

> [oracle@github-presubmit-dg-mfielding-dg6-1 ~]$ echo $ORACLE_SID
> `orcl`
> [oracle@github-presubmit-dg-mfielding-dg6-1 ~]$ echo "show parameter db_unique_name" | sqlplus -s / as sysdba
> 
> NAME                     TYPE     VALUE
> db_unique_name                 string     `orcl`
> [oracle@github-presubmit-dg-mfielding-dg6-1 ~]$ echo "select min(name) from v\$datafile;" | sqlplus -s / as sysdba
> 
> MIN(NAME)
> /u02/`ORCL`/datafile/o1_mf_sysaux_nd91wdno_.dbf

Why, Oracle, why?

Sample run, after the change:  https://gist.github.com/mfielding/f8ad950aa54ea51a5bcab67f91a351ba