### PR TITLE
Incorporate instance name in cron `.out` and RMAN `.log` files for backups

### DIFF
--- a/roles/db-backups/templates/rman_arch_backup.sh.j2
+++ b/roles/db-backups/templates/rman_arch_backup.sh.j2
@@ -50,8 +50,8 @@ fi
 #
 # We can now build the output file and log file names
 #
-outfile="${log_dir}/rman_${start_ts}_${type}.out"
-logfile="${log_dir}/rman_${start_ts}_${type}.log"
+outfile="${log_dir}/rman_${ora_inst_name}_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${ora_inst_name}_${start_ts}_${type}.log"
 #
 # Set the Oracle env
 #

--- a/roles/db-backups/templates/rman_delete_arch.sh.j2
+++ b/roles/db-backups/templates/rman_delete_arch.sh.j2
@@ -36,8 +36,8 @@ fi
 #
 # We can now build the output file and log file names
 #
-outfile="${log_dir}/rman_${start_ts}_${type}.out"
-logfile="${log_dir}/rman_${start_ts}_${type}.log"
+outfile="${log_dir}/rman_${ora_inst_name}_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${ora_inst_name}_${start_ts}_${type}.log"
 #
 # Set the Oracle env
 #

--- a/roles/db-backups/templates/rman_full_backup.sh.j2
+++ b/roles/db-backups/templates/rman_full_backup.sh.j2
@@ -55,8 +55,8 @@ fi
 #
 # We can now build the output file and log file names
 #
-outfile="${log_dir}/rman_${start_ts}_${type}.out"
-logfile="${log_dir}/rman_${start_ts}_${type}.log"
+outfile="${log_dir}/rman_${ora_inst_name}_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${ora_inst_name}_${start_ts}_${type}.log"
 #
 # Set the Oracle env
 #


### PR DESCRIPTION
## Change Description:

Add instance name to backup cron `.out` and RMAN `.log` files for clarity (particularly relevant on installations with multiple instances per server).

## Solution Overview:

If multiple database instances are running on the same server, then it's impossible to tell by the file name alone, which instance/database generated the cron output and backup log files. As while the backup pieces themselves do include the instance name in file names, the cron output files and RMAN log files do not.

This can make troubleshooting difficult, and is even more problematic when there are multiple instances running on the same server (as the `.out` and `.log` files are all written to a common logs directory).

**Solution is to simply add the Oracle instance name variable to cron output file and RMAN log files for additional clarity.**

Exactly where the instance name is incorporated into the file name is not of material importance as long as it is there. For example, the updated file name could be `rman_ORCL_2025-09-15_00-00-00_FULL.log` or `ORCL_rman_2025-09-15_00-00-00_FULL.log` or `rman_2025-09-15_00-00-00_FULL.ORCL.log`.

It is also likely advisable to include the **instance name** in the file name and **not** the target database name. The latter is usually trivially simplistic to derive from the former so including both probably adds little value. However if in an Oracle RAC environment where the backup output/log files were written to a common location (such as an NFS share), it would be more meaningful to know which instance ran the command. The instance name is also the first argument passed into the backup scripts - again this is meaningful and can help identify a misconfiguration.

### Example showing that the file names are not sufficiently descriptive:

The issue is very obvious: no indication of which database (instance) generated the files:

```plaintext
[oracle@server ~/logs]$ ls -tlr
total 72
-rw-r--r--. 1 oracle oinstall 17454 Sep 15 12:39 rman_2025-09-15_12-39-16_FULL.log
-rw-r--r--. 1 oracle oinstall   496 Sep 15 12:39 rman_2025-09-15_12-39-16_FULL.out
-rw-r--r--. 1 oracle oinstall  6279 Sep 15 12:39 rman_2025-09-15_12-39-40_ARCH.log
-rw-r--r--. 1 oracle oinstall   450 Sep 15 12:39 rman_2025-09-15_12-39-40_ARCH.out
-rw-r--r--. 1 oracle oinstall 16635 Sep 15 13:06 rman_2025-09-15_13-05-36_FULL.log
-rw-r--r--. 1 oracle oinstall   496 Sep 15 13:06 rman_2025-09-15_13-05-36_FULL.out
-rw-r--r--. 1 oracle oinstall  5614 Sep 15 13:06 rman_2025-09-15_13-06-06_ARCH.log
-rw-r--r--. 1 oracle oinstall   450 Sep 15 13:06 rman_2025-09-15_13-06-06_ARCH.out

[oracle@server ~/logs]$
```

But we can see from the RMAN `.log` files that there are actually multiple databases being backed-up:

```plaintext
[oracle@server ~/logs]$ grep 'connected to target database' *
rman_2025-09-15_12-39-16_FULL.log:connected to target database: TEST1 (DBID=1588933547)
rman_2025-09-15_12-39-40_ARCH.log:connected to target database: TEST1 (DBID=1588933547)
rman_2025-09-15_13-05-36_FULL.log:connected to target database: PROD1 (DBID=2433235900)
rman_2025-09-15_13-06-06_ARCH.log:connected to target database: PROD1 (DBID=2433235900)

[oracle@server ~/logs]$
```

### Example illustrating issue:

Even when checking the cron `.out` file (which may be necessary if the RMAN command fails and no `.log` file is created, there is no indication as to which instance/database generated the file:

```plaintext
[oracle@server ~/logs]$ ls -tlr
total 36
-rw-r--r--. 1 oracle oinstall 17454 Sep 15 12:39 rman_2025-09-15_12-39-16_FULL.log
-rw-r--r--. 1 oracle oinstall   496 Sep 15 12:39 rman_2025-09-15_12-39-16_FULL.out
-rw-r--r--. 1 oracle oinstall  6279 Sep 15 12:39 rman_2025-09-15_12-39-40_ARCH.log
-rw-r--r--. 1 oracle oinstall   450 Sep 15 12:39 rman_2025-09-15_12-39-40_ARCH.out

[oracle@server ~/logs]$ more rman_2025-09-15_12-39-16_FULL.out

Recovery Manager: Release 19.0.0.0.0 - Production on Mon Sep 15 12:39:16 2025
Version 19.3.0.0.0

Copyright (c) 1982, 2019, Oracle and/or its affiliates.  All rights reserved.

RMAN>
echo set on

RMAN>   spool log to '/home/oracle/logs/rman_2025-09-15_12-39-16_FULL.log'
RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> RMAN> 2> 3> 4> 5> 6> 7> 8> 9> 10> RMAN> RMAN> RMAN> RMAN>
Spooling for log turned off

Recovery Manager19.3.0.0.0

RMAN>

Recovery Manager complete.
[oracle@server ~/logs]$
```

Of course, the instance name is included in the `.log` file, but as mentioned, this file possibly may not exist in the case of an RMAN or script failure:

```plaintext
$ more rman_2025-09-15_12-39-16_FULL.log

Spooling started in log file: /home/oracle/logs/rman_2025-09-15_12-39-16_FULL.log

Recovery Manager19.3.0.0.0

RMAN>   connect target *

connected to target database: TEST1 (DBID=1588933547)

RMAN>
...
```

## Change Results:

Example with this change:

```plaintext
[oracle@server ~/logs]$ ls -tlr
total 36
-rw-r--r--. 1 oracle oinstall 21317 Sep 15 13:09 rman_prod1_2025-09-15_13-09-03_FULL.log
-rw-r--r--. 1 oracle oinstall   502 Sep 15 13:09 rman_prod1_2025-09-15_13-09-03_FULL.out
-rw-r--r--. 1 oracle oinstall  6267 Sep 15 13:09 rman_prod1_2025-09-15_13-09-29_ARCH.log
-rw-r--r--. 1 oracle oinstall   456 Sep 15 13:09 rman_prod1_2025-09-15_13-09-29_ARCH.out

[oracle@server ~/logs]$
```