### PR TITLE
Broaden package managed process check/kill and make task idempotent

### DIFF
--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -13,9 +13,18 @@
 # limitations under the License.
 
 ---
-- name: Ensure yum is not running, send Ctrl-C if it is
-  shell: pidof -x /usr/bin/yum /bin/yum | xargs -t -r -n 1 kill -INT
+- name: Stop package manager processes if they exist (using a CTRL-c equivalent SIGINT)
+  shell: |
+    pids=$(pidof -x /usr/bin/dnf /usr/bin/yum /usr/bin/dnf-3 /bin/dnf /bin/yum /bin/dnf-3)
+    if [ -n "$pids" ]; then
+      echo "Killing processes with PIDs: $pids"
+      kill -INT $pids
+    else
+      echo "No running package manager processes found."
+    fi
+  register: package_managed_proc_kill
   when: install_os_packages
+  changed_when: package_managed_proc_kill.stdout != 'No running package manager processes found.'
   tags: os_packages
 
 - name: Remove ntpd package


### PR DESCRIPTION
## Change Description:

Enhance initial task of detecting and killing running package manages processes (and make task idempotent).

## Solution Overview:

The existing task for detecting running package manager processes is not sufficiently robust as it is only looking for running `yum` processes. The toolkit has run into issues in past testing when the package manager process has a different name as it can be any of `yum`, `dnf` or `dnf-3`.

Also, the existing task is not idempotent and always results in a "**changed**" status.

This change resolves both of those issues by detecting a wider range of possible process names and by leveraging the `changed_when:` key-value.

## Test Results:

When a package managed process is running on the managed host target (simulated by simply running `sudo dnf install git` and then waiting on the confirmation prompt), the task shows a changed status:

```plaintext
...
TASK [Gathering Facts] *************************************************************************************************************************************************************
ok: [10.2.80.121]

TASK [base-provision : Stop package manager processes if they exist (using a CTRL-c equivalent SIGINT)] ****************************************************************************
changed: [10.2.80.121]

...
```

And the resulting command on the managed host was indeed killed:

```plaintext
...
Total download size: 14 M
Installed size: 46 M
Is this ok [y/N]: Operation aborted.
```

And when no package manager process is running, the task is properly idempotent:

```plaintext
...
TASK [Gathering Facts] *************************************************************************************************************************************************************
ok: [10.2.80.121]

TASK [base-provision : Stop package manager processes if they exist (using a CTRL-c equivalent SIGINT)] ****************************************************************************
ok: [10.2.80.121]

...
```