### PR TITLE
Add logging to `apply-patch.sh` and other minor optimizations and formatting changes to shell scripts

### DIFF
--- a/apply-patch.sh
+++ b/apply-patch.sh
@@ -17,19 +17,38 @@ echo Command used:
 echo "$0 $@"
 echo
 
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+#
+# Ansible logs directory, the log file name is created later one
+#
+LOG_DIR="./logs"
+LOG_FILE="${LOG_DIR}/patch"
+if [[ ! -d "${LOG_DIR}" ]]; then
+  mkdir -p "${LOG_DIR}"
+  if [ $? -eq 0 ]; then
+    printf "\n\033[1;36m%s\033[m\n\n" "Successfully created the ${LOG_DIR} directory to save the ansible logs."
+  else
+    printf "\n\033[1;31m%s\033[m\n\n" "Unable to create the ${LOG_DIR} directory to save the ansible logs; cannot continue."
+    exit 123
+  fi
+fi
+
+shopt -s nocasematch
+
 # Check if we're using the Mac stock getopt and fail if true
 out="$(getopt -T)"
 if [ $? != 4 ]; then
-    echo -e "Your getopt does not support long parameters, possibly you're on a Mac, if so please install gnu-getopt with brew"
-    echo -e "\thttps://brewformulas.org/Gnu-getopt"
-    exit
+  echo -e "Your getopt does not support long parameters, possibly you're on a Mac, if so please install gnu-getopt with brew"
+  echo -e "\thttps://brewformulas.org/Gnu-getopt"
+  exit
 fi
 
 ORA_VERSION="${ORA_VERSION:-19.3.0.0.0}"
 ORA_VERSION_PARAM='^(21\.3\.0\.0\.0|19\.3\.0\.0\.0|18\.0\.0\.0\.0|12\.2\.0\.1\.0|12\.1\.0\.2\.0|11\.2\.0\.4\.0)$'
 
-ORA_RELEASE="${ORA_RELEASE}"
-ORA_RELEASE_PARAM=""
+ORA_RELEASE="${ORA_RELEASE:-latest}"
+ORA_RELEASE_PARAM="^(base|latest|[0-9]{,2}\.[0-9]{,2}\.[0-9]{,2}\.[0-9]{,2}\.[0-9]{,6})$"
 
 ORA_SWLIB_BUCKET="${ORA_SWLIB_BUCKET}"
 ORA_SWLIB_BUCKET_PARAM="^(gs:\/\/|https?:\/\/)"
@@ -51,6 +70,12 @@ ORA_DB_NAME_PARAM="^[a-zA-Z0-9_$]+$"
 #
 INVENTORY_FILE="${INVENTORY_FILE:-./inventory_files/inventory}"
 
+#
+# Build the log file for this session
+#
+LOG_FILE="${LOG_FILE}_${ORA_DB_NAME}_${TIMESTAMP}.log"
+export ANSIBLE_LOG_PATH=${LOG_FILE}
+
 # Suppress displaying hosts if a "when" condition isn't satisfied, to reduce overall output file size.
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 ###
@@ -65,69 +90,69 @@ VALIDATE=0
 options="$(getopt --longoptions "$GETOPT_LONG" --options "$GETOPT_SHORT" -- "$@")"
 
 [ $? -eq 0 ] || {
-    echo "Invalid options provided: $@" >&2
-    exit 1
+  echo "Invalid options provided: $@" >&2
+  exit 1
 }
 
 eval set -- "$options"
 
 while true; do
-    case "$1" in
-    --ora-version)
-        ORA_VERSION="$2"
-        if [[ "${ORA_VERSION}" = "21" ]]   ; then ORA_VERSION="21.3.0.0.0"; fi
-        if [[ "${ORA_VERSION}" = "19" ]]   ; then ORA_VERSION="19.3.0.0.0"; fi
-        if [[ "${ORA_VERSION}" = "18" ]]   ; then ORA_VERSION="18.0.0.0.0"; fi
-        if [[ "${ORA_VERSION}" = "12" ]]   ; then ORA_VERSION="12.2.0.1.0"; fi
-        if [[ "${ORA_VERSION}" = "12.2" ]] ; then ORA_VERSION="12.2.0.1.0"; fi
-        if [[ "${ORA_VERSION}" = "12.1" ]] ; then ORA_VERSION="12.1.0.2.0"; fi
-        if [[ "${ORA_VERSION}" = "11" ]]   ; then ORA_VERSION="11.2.0.4.0"; fi
-        shift
-        ;;
-    --ora-release)
-        ORA_RELEASE="$2"
-        shift
-        ;;
-    --ora-swlib-bucket)
-        ORA_SWLIB_BUCKET="$2"
-        shift
-        ;;
-    --ora-swlib-type)
-        ORA_SWLIB_TYPE="$2"
-        shift
-        ;;
-    --ora-swlib-path)
-        ORA_SWLIB_PATH="$2"
-        shift
-        ;;
-    --ora-staging)
-        ORA_STAGING="$2"
-        shift
-        ;;
-    --inventory-file)
-        INVENTORY_FILE="$2"
-        shift
-        ;;
-    --ora-db-name)
-        ORA_DB_NAME="$2"
-        shift
-        ;;
-    --validate)
-        VALIDATE=1
-        ;;
-    --help | -h)
-        echo -e "\tUsage: $(basename $0)" >&2
-        echo "${GETOPT_MANDATORY}" | sed 's/,/\n/g' | sed 's/:/ <value>/' | sed 's/\(.\+\)/\t --\1/'
-        echo "${GETOPT_OPTIONAL}"  | sed 's/,/\n/g' | sed 's/:/ <value>/' | sed 's/\(.\+\)/\t [ --\1 ]/'
-        echo -e "\t -- [parameters sent to ansible]"
-        exit 2
-        ;;
-    --)
-        shift
-        break
-        ;;
-    esac
+  case "$1" in
+  --ora-version)
+    ORA_VERSION="$2"
+    if [[ "${ORA_VERSION}" = "21" ]]   ; then ORA_VERSION="21.3.0.0.0"; fi
+    if [[ "${ORA_VERSION}" = "19" ]]   ; then ORA_VERSION="19.3.0.0.0"; fi
+    if [[ "${ORA_VERSION}" = "18" ]]   ; then ORA_VERSION="18.0.0.0.0"; fi
+    if [[ "${ORA_VERSION}" = "12" ]]   ; then ORA_VERSION="12.2.0.1.0"; fi
+    if [[ "${ORA_VERSION}" = "12.2" ]] ; then ORA_VERSION="12.2.0.1.0"; fi
+    if [[ "${ORA_VERSION}" = "12.1" ]] ; then ORA_VERSION="12.1.0.2.0"; fi
+    if [[ "${ORA_VERSION}" = "11" ]]   ; then ORA_VERSION="11.2.0.4.0"; fi
     shift
+    ;;
+  --ora-release)
+    ORA_RELEASE="$2"
+    shift
+    ;;
+  --ora-swlib-bucket)
+    ORA_SWLIB_BUCKET="$2"
+    shift
+    ;;
+  --ora-swlib-type)
+    ORA_SWLIB_TYPE="$2"
+    shift
+    ;;
+  --ora-swlib-path)
+    ORA_SWLIB_PATH="$2"
+    shift
+    ;;
+  --ora-staging)
+    ORA_STAGING="$2"
+    shift
+    ;;
+  --inventory-file)
+    INVENTORY_FILE="$2"
+    shift
+    ;;
+  --ora-db-name)
+    ORA_DB_NAME="$2"
+    shift
+    ;;
+  --validate)
+    VALIDATE=1
+    ;;
+  --help | -h)
+    echo -e "\tUsage: $(basename $0)" >&2
+    echo "${GETOPT_MANDATORY}" | sed 's/,/\n/g' | sed 's/:/ <value>/' | sed 's/\(.\+\)/\t --\1/'
+    echo "${GETOPT_OPTIONAL}"  | sed 's/,/\n/g' | sed 's/:/ <value>/' | sed 's/\(.\+\)/\t [ --\1 ]/'
+    echo -e "\t -- [parameters sent to ansible]"
+    exit 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  esac
+  shift
 done
 #
 # Parameter defaults
@@ -135,53 +160,53 @@ done
 [[ "$ORA_STAGING" == "" ]] && {
     ORA_STAGING=$ORA_SWLIB_PATH
 }
+
 #
 # Variables verification
 #
-shopt -s nocasematch
-
 [[ ! "$ORA_VERSION" =~ $ORA_VERSION_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-version: $ORA_VERSION"
-    exit 1
+  echo "Incorrect parameter provided for ora-version: $ORA_VERSION"
+  exit 1
 }
 [[ ! "$ORA_RELEASE" =~ $ORA_RELEASE_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-release: $ORA_RELEASE"
-    exit 1
+  echo "Incorrect parameter provided for ora-release: $ORA_RELEASE"
+  exit 1
 }
 [[ ! "$ORA_SWLIB_BUCKET" =~ $ORA_SWLIB_BUCKET_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-swlib-bucket: $ORA_SWLIB_BUCKET"
-    exit 1
+  echo "Incorrect (or no) parameter provided for ora-swlib-bucket: $ORA_SWLIB_BUCKET"
+  echo "Example: gs://my-gcs-bucket"
+  exit 1
 }
 [[ ! "$ORA_SWLIB_TYPE" =~ $ORA_SWLIB_TYPE_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-swlib-type: $ORA_SWLIB_TYPE"
-    exit 1
+  echo "Incorrect parameter provided for ora-swlib-type: $ORA_SWLIB_TYPE"
+  exit 1
 }
 [[ ! "$ORA_SWLIB_PATH" =~ $ORA_SWLIB_PATH_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-swlib-path: $ORA_SWLIB_PATH"
-    exit 1
+  echo "Incorrect parameter provided for ora-swlib-path: $ORA_SWLIB_PATH"
+  exit 1
 }
 [[ ! "$ORA_STAGING" =~ $ORA_STAGING_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-staging: $ORA_STAGING"
-    exit 1
+  echo "Incorrect parameter provided for ora-staging: $ORA_STAGING"
+  exit 1
 }
 [[ ! "$ORA_DB_NAME" =~ $ORA_DB_NAME_PARAM ]] && {
-    echo "Incorrect parameter provided for ora-db-name: $ORA_DB_NAME"
-    exit 1
+  echo "Incorrect parameter provided for ora-db-name: $ORA_DB_NAME"
+  exit 1
 }
 
 # If downloading from GCS (or any other address) via URL
 if [[ "${ORA_SWLIB_BUCKET}" == http://* || "${ORA_SWLIB_BUCKET}" == https://* ]]; then
-    ORA_SWLIB_TYPE=URL
+  ORA_SWLIB_TYPE=URL
 fi
 
 # Mandatory options
 if [ "${ORA_SWLIB_BUCKET}" = "" ]; then
-    echo "Please specify a GS bucket with --ora-swlib-bucket"
-    exit 2
+  echo "Please specify a GS bucket with --ora-swlib-bucket"
+  exit 2
 fi
 if [[ ! -s ${INVENTORY_FILE} ]]; then
-    echo "Please specify the inventory file using --inventory-file <file_name>"
-    exit 2
+  echo "Please specify the inventory file using --inventory-file <file_name>"
+  exit 2
 fi
 
 #
@@ -209,18 +234,18 @@ ANSIBLE_PARAMS="${ANSIBLE_PARAMS} $@"
 echo "Ansible params: ${ANSIBLE_PARAMS}"
 
 if [ $VALIDATE -eq 1 ]; then
-    echo "Exiting because of --validate"
-    exit
+  echo "Exiting because of --validate"
+  exit
 fi
 
 export ANSIBLE_NOCOWS=1
 
 ANSIBLE_PLAYBOOK="ansible-playbook"
 if ! type ansible-playbook >/dev/null 2>&1; then
-    echo "Ansible executable not found in path"
-    exit 3
+  echo "Ansible executable not found in path"
+  exit 3
 else
-    echo "Found Ansible: $(type ansible-playbook)"
+  echo "Found Ansible: $(type ansible-playbook)"
 fi
 
 # exit on any error from the following scripts
@@ -228,5 +253,16 @@ set -e
 
 echo "Running Ansible playbook: ${ANSIBLE_PLAYBOOK} ${ANSIBLE_PARAMS} patch.yml"
 ${ANSIBLE_PLAYBOOK} ${ANSIBLE_PARAMS} patch.yml
+
+#
+# Show the files used by this session
+#
+printf "\n\033[1;36m%s\033[m\n" "Files used by this session:"
+for FILE in "${INVENTORY_FILE}" "${LOG_FILE}"; do
+  if [[ -f "${FILE}" ]]; then
+    printf "\t\033[1;36m- %s\033[m\n" "${FILE}"
+  fi
+done
+printf "\n"
 
 exit 0

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -618,11 +618,10 @@ ORA_STAGING="${ORA_STAGING:-$ORA_SWLIB_PATH}"
 [[ "$COMPATIBLE_RDBMS" == "0" ]] && {
   COMPATIBLE_RDBMS=$ORA_VERSION
 }
+
 #
 # Variables verification
 #
-shopt -s nocasematch
-
 [[ ! "$ORA_VERSION" =~ $ORA_VERSION_PARAM ]] && {
   echo "Incorrect parameter provided for ora-version: $ORA_VERSION"
   exit 1
@@ -1034,7 +1033,7 @@ else
   exit 124
 fi
 #
-# Build the logfile for this session
+# Build the log file for this session
 #
 if [[ "${CLUSTER_TYPE}" = "RAC" ]] || [[ "${CLUSTER_TYPE}" = "DG" ]]; then
   LOG_FILE="${LOG_FILE}_${ORA_DB_NAME}_${TIMESTAMP}_${CLUSTER_TYPE}.log"


### PR DESCRIPTION
## Change Description:

Copy logging functionality from `install-oracle.sh` to `apply-patch.sh` and standardize formatting.

## Solution Overview:

Updates to the `apply-patch.sh` shell script to make it more similar to the `install-oracle.sh` script. Specifically by incorporating the following script characteristics from `install-oracle.sh`:

1. Generating a log file in the logs subdirectory
2. Showing a summary of files (including the log file name) upon completion
3. Standardizing shell script formatting of two space indentations

Additionally, removed a redundant `shopt -s nocasematch` line from both scripts. And synchronized a few other lines between the two files (i.e. setting for the `ORA_RELEASE` and `ORA_RELEASE_PARAM` script parameters).

> **NOTE:** No other functional changes made to the toolkit in this change. No changes to any `.yaml` task files or playbooks.

## Test Results:

- [Applying patch using XFS storage](https://gist.github.com/simonpane/7ee21c71f9e76e722dbf7a3a47b1a435)
- [Applying patch using ASM storage](https://gist.github.com/simonpane/30662a1d634da37a31758cc0b43f09c3)