### PR TITLE
Database start/stop scripts for FS installations

### DIFF
--- a/config-db.yml
+++ b/config-db.yml
@@ -96,6 +96,14 @@
       when: cluster_type == "DG"
       tags: dg-create,dg-mode
 
+    - include_role:
+        name: db-start
+      when:
+        - cluster_type != "RAC"
+        - ora_disk_management == "fs"
+        - not free_edition
+      tags: db-start
+
 - name: Get and Log Oracle DBID
   hosts: dbasm
   remote_user: "{{ oracle_user }}"

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -275,6 +275,7 @@
     - "/etc/systemd/system/graphical.target.wants/oracle-ohasd.service"
     - "/etc/systemd/system/multi-user.target.wants/oracle-ohasd.service"
     - "/etc/systemd/system/multi-user.target.wants/oracleasm.service"
+    - "/lib/systemd/system/dbora.service"
     - "/opt/oracle.ahf"
     - "/var/log/oracleasm"
     - "/var/log/oracleohasd"

--- a/roles/db-start/meta/main.yml
+++ b/roles/db-start/meta/main.yml
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+dependencies:
+  - role: common

--- a/roles/db-start/tasks/main.yml
+++ b/roles/db-start/tasks/main.yml
@@ -1,0 +1,66 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Ensure scripts directory is present
+  file:
+    path: "{{ scripts_dir }}"
+    state: directory
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+    mode: u=wrx,go=
+
+- name: Copy startup and shutdown scripts to target server
+  become: true
+  become_user: "{{ oracle_user }}"
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ scripts_dir }}/{{ item }}"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+    mode: u=wrx,go=
+  with_items:
+    - "start_all.sh"
+    - "stop_all.sh"
+  tags: db-start
+
+- name: Setup automatic Oracle database stop and start services
+  become: true
+  block:
+    - name: Ensure autostart in oratab
+      lineinfile:
+        path: /etc/oratab
+        regexp: '^{{ oracle_sid }}\:([^:]+)\:N'
+        line: '{{ oracle_sid }}:\1:Y'
+        backrefs: true
+        backup: true
+
+    - name: Copy dbora.service definition to target server
+      template:
+        src: "dbora.service.j2"
+        dest: "/lib/systemd/system/dbora.service"
+        owner: root
+        group: root
+        mode: u=wr,g=r,o=r
+
+    - name: Reload systemd
+      systemd:
+        daemon_reload: true
+
+    - name: Enable automatic stop and start of Oracle instance
+      systemd:
+        name: dbora.service
+        enabled: true
+  ignore_errors: true
+  tags: db-start

--- a/roles/db-start/templates/dbora.service.j2
+++ b/roles/db-start/templates/dbora.service.j2
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=dbora.service
+Requires=network.target local-fs.target swap.target sysinit.target
+After=network.target local-fs.target swap.target sysinit.target
+Before=umount.target shutdown.target
+RequiresMountsFor={% for mount in oracle_user_data_mounts %} {{ mount.mount_point }}{% endfor %}
+
+[Service]
+LimitMEMLOCK=infinity
+LimitNOFILE=65535
+
+Type=forking
+User={{ oracle_user }}
+Group={{ oracle_group }}
+Restart=no
+KillMode=control-group
+TimeoutStopSec=60
+ExecStart=/bin/bash -c '{{ scripts_dir }}/start_all.sh'
+ExecStop=/bin/bash -c '{{ scripts_dir }}/stop_all.sh'
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/db-start/templates/start_all.sh.j2
+++ b/roles/db-start/templates/start_all.sh.j2
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+while IFS=':' read -r ORACLE_SID ORACLE_HOME AUTOSTART_FLAG; do
+    if [[ "$AUTOSTART_FLAG" =~ [Yy] ]]; then
+        PATH_SAVE=$PATH
+        LD_LIBRARY_PATH_SAVE=$LD_LIBRARY_PATH
+        export ORACLE_SID ORACLE_HOME
+        export PATH=$ORACLE_HOME/bin:$PATH
+        export LD_LIBRARY_PATH=$ORACLE_HOME/lib:$LD_LIBRARY_PATH
+        if ! pgrep -f "tnslsnr.*{{ listener_name }}" ; then
+            echo Starting listener {{ listener_name }}
+            $ORACLE_HOME/bin/lsnrctl start {{ listener_name }}
+        fi
+        if ! pgrep -f "ora_smon_$ORACLE_SID" ; then
+            # startup is in separate sqlplus calls due to dbms_output not working correctly
+            echo Starting Oracle instance $ORACLE_SID
+            sqlplus -S / as sysdba <<EOF
+WHENEVER OSERROR EXIT FAILURE
+WHENEVER SQLERROR EXIT FAILURE
+STARTUP MOUNT;
+EXIT;
+EOF
+            if [ $? -ne 0 ]; then
+                echo ERROR: Failed to mount $ORACLE_SID
+            else
+                IFS="," read db_role db_mode <<<$(sqlplus -S / as sysdba <<EOF
+SET PAGES 0 FEED OFF VERIFY OFF HEADING OFF ECHO OFF COLSEP , TRIMSPOOL ON TAB OFF
+SELECT database_role, open_mode FROM v\$database;
+EXIT;
+EOF
+)
+                if [[ "$db_role" =~ "PRIMARY" ]]; then
+                    echo "Current role is PRIMARY."
+                    if [[ "$db_mode" != "READ WRITE" ]]; then
+                        echo "Opening database."
+                        sqlplus -S / as sysdba <<EOF
+WHENEVER OSERROR EXIT FAILURE
+WHENEVER SQLERROR EXIT FAILURE
+SET PAGES 0 FEED OFF VERIFY OFF HEADING OFF ECHO OFF
+ALTER DATABASE OPEN;
+EXIT;
+EOF
+                    else
+                        echo "Database is already open."
+                    fi
+                elif [[ "$db_role" =~ "PHYSICAL STANDBY" ]]; then
+                    echo "Current role is PHYSICAL STANDBY. Starting managed recovery."
+                    sqlplus -S / as sysdba <<EOF
+ALTER DATABASE RECOVER MANAGED STANDBY DATABASE DISCONNECT FROM SESSION;
+EXIT;
+EOF
+                else
+                    echo "Unrecognized database role: $db_role. Database will remain in MOUNT mode."
+                fi
+            fi
+        fi
+        PATH=$PATH_SAVE
+        LD_LIBRARY_PATH=$LD_LIBRARY_PATH_SAVE
+        export PATH LD_LIBRARY_PATH
+    fi
+done < <(sed 's/#.*//; /^[[:space:]]*$/d' /etc/oratab)

--- a/roles/db-start/templates/stop_all.sh.j2
+++ b/roles/db-start/templates/stop_all.sh.j2
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+while IFS=':' read -r ORACLE_SID ORACLE_HOME AUTOSTART_FLAG; do
+    if [[ "$AUTOSTART_FLAG" =~ [Yy] ]]; then
+        PATH_SAVE=$PATH
+        LD_LIBRARY_PATH_SAVE=$LD_LIBRARY_PATH
+        export ORACLE_SID ORACLE_HOME
+        export PATH=$ORACLE_HOME/bin:$PATH
+        export LD_LIBRARY_PATH=$ORACLE_HOME/lib:$LD_LIBRARY_PATH
+        if pgrep -f "tnslsnr.*{{ listener_name }}" ; then
+            echo Stopping listener {{ listener_name }}
+            $ORACLE_HOME/bin/lsnrctl stop {{ listener_name }}
+        fi
+        if pgrep -f "ora_smon_$ORACLE_SID" ; then
+            echo Stopping Oracle instance $ORACLE_SID
+            sqlplus -S / as sysdba << EOF
+SET SERVEROUTPUT ON;
+SET TERMOUT ON FEED OFF ECHO OFF;
+DECLARE
+    v_database_role VARCHAR2(30);
+    v_open_mode     VARCHAR2(30);
+BEGIN
+    SELECT database_role, open_mode INTO v_database_role, v_open_mode FROM V\$DATABASE;
+    IF v_database_role = 'PHYSICAL STANDBY' THEN
+        DBMS_OUTPUT.PUT_LINE('Current role is PHYSICAL STANDBY. Stopping managed recovery.');
+        EXECUTE IMMEDIATE 'ALTER DATABASE RECOVER MANAGED STANDBY DATABASE CANCEL';
+    END IF;
+END;
+/
+WHENEVER OSERROR EXIT FAILURE
+WHENEVER SQLERROR EXIT FAILURE
+SHUTDOWN IMMEDIATE;
+EXIT;
+EOF
+            if [ $? -ne 0 ]; then
+                echo ERROR: Failed to stop $ORACLE_SID
+            else
+                echo Oracle instance $ORACLE_SID is stopped
+            fi
+        fi
+        PATH=$PATH_SAVE
+        LD_LIBRARY_PATH=$LD_LIBRARY_PATH_SAVE
+        export PATH LD_LIBRARY_PATH
+    fi
+done < <(sed 's/#.*//; /^[[:space:]]*$/d' /etc/oratab)


### PR DESCRIPTION
## Change Description:
Add automatic start/stop scripts for Oracle instances running on file system.

## Solution Overview:
The changes are applied only to the databases running on FS. In case of GI the automatic startup is handled by cluster services.
Custom scripts are used for startup/shutdown since standard dbstart doesn't handle Standby databases.
A service `dbora.service` is added to the system which calls `start_all.sh/stop_all.sh` scripts.

## Test Commands:
Testing was done with 19c and 23ai FREE.

19c
```
time ./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition EE \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --ora-disk-mgmt FS \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"},{"purpose":"data","blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"u03","fstype":"xfs","mount_point":"/u03","mount_opts":"nofail"},{"purpose":"reco","blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"u04","fstype":"xfs","mount_point":"/u04","mount_opts":"nofail"}]' \
  --ora-data-destination "/u03/app/oracle/oradata" \
  --ora-reco-destination "/u04/app/oracle/fast_recovery_area" \
  --backup-dest "/u04/app/oracle/backups"  
```

FREE
```
time ./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition FREE \
  --ora-version 23 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/free-edition \
  --ora-disk-mgmt FS \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"},{"purpose":"data","blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"u03","fstype":"xfs","mount_point":"/u03","mount_opts":"nofail"},{"purpose":"reco","blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"u04","fstype":"xfs","mount_point":"/u04","mount_opts":"nofail"}]' \
  --ora-data-destination "/u03/app/oracle/oradata" \
  --ora-reco-destination "/u04/app/oracle/fast_recovery_area" \
  --backup-dest "/u04/app/oracle/backups" 
```

19c Standby
```
time ./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname ${INSTANCE_HOSTNAME} \
  --primary-ip-addr ${PRIMARY_IP_ADDR} \
  --cluster-type DG \
  --ora-edition EE \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --ora-disk-mgmt FS \
  --ora-db-name ora19 \
  --ora-data-mounts-json '[{"purpose":"software","blk_device":"/dev/disk/by-id/google-oracle-disk-1","name":"u01","fstype":"xfs","mount_point":"/u01","mount_opts":"nofail"},{"purpose":"data","blk_device":"/dev/disk/by-id/google-oracle-asm-1","name":"u03","fstype":"xfs","mount_point":"/u03","mount_opts":"nofail"},{"purpose":"reco","blk_device":"/dev/disk/by-id/google-oracle-asm-2","name":"u04","fstype":"xfs","mount_point":"/u04","mount_opts":"nofail"}]' \
  --ora-data-destination "/u03/app/oracle/oradata" \
  --ora-reco-destination "/u04/app/oracle/fast_recovery_area" \
  --backup-dest "/u04/app/oracle/backups"  
```

### Test Prep:

### Test 1: details:
dbora.service is added into the system. Following lines are seen in the `/var/log/messages` and alert log:

```
# shutdown
Aug 26 05:57:24 hostname bash[2116]: Stopping Oracle instance ORCL

2025-08-26T05:57:24.478353-04:00
Shutting down ORACLE instance (immediate) (OS id: 2151)
2025-08-26T05:57:24.478512-04:00
Shutdown is initiated by sqlplus@hostname (TNS V1-V3).
...
2025-08-26T05:57:57.668392-04:00
Instance shutdown complete (OS id: 2151)

# startup
Aug 26 05:50:52 hostname bash[1493]: Database mounted.
Aug 26 05:50:52 hostname bash[1153]: Current role is PRIMARY.
Aug 26 05:50:52 hostname bash[1153]: Opening database.
Aug 26 05:50:58 hostname systemd[1]: Started dbora.service.

# 19c standby startup
Sep 11 08:36:49 host_name bash[1294]: Total System Global Area 7600074848 bytes
Sep 11 08:36:49 host_name bash[1294]: Fixed Size#011#011    9195616 bytes
Sep 11 08:36:49 host_name bash[1294]: Variable Size#011#011 1291845632 bytes
Sep 11 08:36:49 host_name bash[1294]: Database Buffers#011 6291456000 bytes
Sep 11 08:36:49 host_name bash[1294]: Redo Buffers#011#011    7577600 bytes
Sep 11 08:36:53 host_name bash[1294]: Database mounted.
Sep 11 08:36:53 host_name bash[1145]: Current role is PHYSICAL STANDBY. Starting managed recovery.
Sep 11 08:36:59 host_name bash[1717]: Database altered.
```
Sep 11 08:36:59 host_name systemd[1]: Started dbora.service.

### Test 2: details:
No services added to FREE as it already has a built-in service.

## Expected Results:
1. Successful shutdown/startup of 19c
2. No changes to 23ai install
3. Successful startup/shutdown of 19c Standby