### PR TITLE
Require passwords to be at least 8 characters in length

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -146,7 +146,7 @@ home_name: "{% if free_edition %}dbhomeFree{% else %}dbhome_1{% endif %}"
 oracle_sid: "{% if db_config_type == 'SI' %}{{ db_name }}{% else %}{{ db_name }}{{ instance_num }}{% endif %}"
 asm_sid: "{% if db_config_type == 'SI' %}+ASM{% else %}+ASM{{ instance_num }}{% endif %}"
 run_initial_bu: true
-password_pattern: "^[a-zA-Z0-9@+~*]{1,30}$"
+password_pattern: "^[a-zA-Z0-9@+~*]{8,30}$"
 
 # Installation options:
 create_db: true


### PR DESCRIPTION
Match password minimums with DBCA's, to avoid errors like

> WARNING] [DBT-06208] The 'PDBADMIN' password entered does not conform to the Oracle recommended standards.\n   CAUSE: \na. Oracle recommends that the password entered should be at least 8 characters in length, contain at least 1 uppercase character, 1 lower case character and 1 digit [0-9]

We won't easily be able to validate everything in the regex, but an 8-character password is a good security precaution anyway.

Failed run: https://gist.github.com/mfielding/1771e292fef043942e616599591ef258