### PR TITLE
Remove eval from Bash scripts where it was used to execute commands

### DIFF
--- a/cleanup-oracle.sh
+++ b/cleanup-oracle.sh
@@ -249,23 +249,6 @@ echo -e "Running with parameters from command line or environment variables:\n"
 set | grep -E '^(ORA_|INVENTORY_)' | grep -v '_PARAM='
 echo
 
-ANSIBLE_PARAMS="-i ${INVENTORY_FILE}"
-ANSIBLE_EXTRA_PARAMS="${*}"
-
-if [[ -n "${ORA_ASM_DISKS_JSON}" ]]; then
-  ANSIBLE_EXTRA_PARAMS=${ANSIBLE_EXTRA_PARAMS}" -e '{\"asm_disk_input\": ${ORA_ASM_DISKS_JSON}}'"
-fi
-if [[ -n "${ORA_DATA_MOUNTS_JSON}" ]]; then
-  ANSIBLE_EXTRA_PARAMS=${ANSIBLE_EXTRA_PARAMS}" -e '{\"data_mounts_input\": ${ORA_DATA_MOUNTS_JSON}}'"
-fi
-
-echo "Ansible params: ${ANSIBLE_EXTRA_PARAMS}"
-
-if [ $VALIDATE -eq 1 ]; then
-    echo "Exiting because of --validate"
-    exit
-fi
-
 export ANSIBLE_NOCOWS=1
 
 ANSIBLE_PLAYBOOK="ansible-playbook"
@@ -276,14 +259,48 @@ else
     echo "Found Ansible: $(type ansible-playbook)"
 fi
 
+# Initialize command array
+declare -a CMD_ARRAY=()
+
+CMD_ARRAY+=($ANSIBLE_PLAYBOOK)
+CMD_ARRAY+=(-i "$INVENTORY_FILE")
+
+if [[ -n "$ANSIBLE_PARAMS" ]]; then
+  echo "Processing ANSIBLE_PARAMS string: [$ANSIBLE_PARAMS]"
+  CMD_ARRAY+=(-e "$ANSIBLE_PARAMS")
+fi
+
+# Add any passthrough arguments from the script command line
+if [[ "$#" -gt 0 ]]; then
+  CMD_ARRAY+=("$@")
+fi
+
+# Add the JSON arguments. Each part must be a separate array element
+if [[ -n "${ORA_ASM_DISKS_JSON}" ]]; then
+  # The '-e' is one element. The JSON string is the next.
+  CMD_ARRAY+=(-e "{\"asm_disk_input\":${ORA_ASM_DISKS_JSON}}")
+fi
+
+if [[ -n "${ORA_DATA_MOUNTS_JSON}" ]]; then
+  CMD_ARRAY+=(-e "{\"data_mounts_input\":${ORA_DATA_MOUNTS_JSON}}")
+fi
+
+if [ $VALIDATE -eq 1 ]; then
+  echo "Exiting because of --validate"
+  exit
+fi
+
 # exit on any error from the following scripts
 set -e
 
 for PLAYBOOK in brute-cleanup.yml; do
-    ANSIBLE_COMMAND="${ANSIBLE_PLAYBOOK} ${ANSIBLE_PARAMS} ${ANSIBLE_EXTRA_PARAMS} ${PLAYBOOK}"
-    echo
-    echo "Running Ansible playbook: ${ANSIBLE_COMMAND}"
-    eval "${ANSIBLE_COMMAND}"
+  # Create a temporary array for this specific run by copying the base array
+  declare -a CMDLINE=("${CMD_ARRAY[@]}")
+  CMDLINE+=("${PLAYBOOK}")
+
+  printf "Running Ansible playbook: %s\n" "${CMDLINE[*]}"
+
+  "${CMDLINE[@]}"
 done
 
 exit 0

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -1123,23 +1123,6 @@ echo -e "Running with parameters from command line or environment variables:\n"
 set | grep -E '^(ORA_|BACKUP_|GCS_|ARCHIVE_|INSTANCE_|PB_|ANSIBLE_|CLUSTER|PRIMARY)' | grep -v '_PARAM='
 echo
 
-ANSIBLE_PARAMS="-i ${INVENTORY_FILE} ${ANSIBLE_PARAMS}"
-ANSIBLE_EXTRA_PARAMS="${*}"
-
-if [[ -n "${ORA_ASM_DISKS_JSON}" ]]; then
-  ANSIBLE_EXTRA_PARAMS="${ANSIBLE_EXTRA_PARAMS} -e '{\"asm_disk_input\":${ORA_ASM_DISKS_JSON}}'"
-fi
-if [[ -n "${ORA_DATA_MOUNTS_JSON}" ]]; then
-  ANSIBLE_EXTRA_PARAMS="${ANSIBLE_EXTRA_PARAMS} -e '{\"data_mounts_input\":${ORA_DATA_MOUNTS_JSON}}'"
-fi
-
-echo "Ansible params: ${ANSIBLE_EXTRA_PARAMS}"
-
-if [ $VALIDATE -eq 1 ]; then
-  echo "Exiting because of --validate"
-  exit
-fi
-
 export ANSIBLE_NOCOWS=1
 
 ANSIBLE_PLAYBOOK="ansible-playbook"
@@ -1150,15 +1133,49 @@ else
   echo "Found Ansible: $(type ansible-playbook)"
 fi
 
+# Initialize command array
+declare -a CMD_ARRAY=()
+
+CMD_ARRAY+=($ANSIBLE_PLAYBOOK)
+CMD_ARRAY+=(-i "$INVENTORY_FILE")
+
+if [[ -n "$ANSIBLE_PARAMS" ]]; then
+  echo "Processing ANSIBLE_PARAMS string: [$ANSIBLE_PARAMS]"
+  CMD_ARRAY+=(-e "$ANSIBLE_PARAMS")
+fi
+
+# Add any passthrough arguments from the script command line
+if [[ "$#" -gt 0 ]]; then
+  CMD_ARRAY+=("$@")
+fi
+
+# Add the JSON arguments. Each part must be a separate array element
+if [[ -n "${ORA_ASM_DISKS_JSON}" ]]; then
+  # The '-e' is one element. The JSON string is the next.
+  CMD_ARRAY+=(-e "{\"asm_disk_input\":${ORA_ASM_DISKS_JSON}}")
+fi
+
+if [[ -n "${ORA_DATA_MOUNTS_JSON}" ]]; then
+  CMD_ARRAY+=(-e "{\"data_mounts_input\":${ORA_DATA_MOUNTS_JSON}}")
+fi
+
+if [ $VALIDATE -eq 1 ]; then
+  echo "Exiting because of --validate"
+  exit
+fi
+
 # exit on any error from the following scripts
 set -e
 
 for PLAYBOOK in ${PB_LIST}; do
-  ANSIBLE_COMMAND="${ANSIBLE_PLAYBOOK} ${ANSIBLE_PARAMS} ${ANSIBLE_EXTRA_PARAMS} ${PLAYBOOK}"
-  echo
-  echo "Running Ansible playbook: ${ANSIBLE_COMMAND}"
-  eval "${ANSIBLE_COMMAND}"
+  # Create a temporary array for this specific run by copying the base array
+  declare -a CMDLINE=("${CMD_ARRAY[@]}")
+  CMDLINE+=("${PLAYBOOK}")
+
+  printf "Running Ansible playbook: %s\n" "${CMDLINE[*]}"
+  "${CMDLINE[@]}"
 done
+
 #
 # Show the files used by this session
 #


### PR DESCRIPTION
## Change Description

Several scripts used `eval` unnecessarily, which can lead to security vulnerabilities.

This change removes the use of `eval` in these scripts, replacing it with an array containing the command and its arguments.

The array is then executed directly.

## Solution Overview

In general, replace this:

```bash
for PLAYBOOK in ${PB_LIST}; do
  ANSIBLE_COMMAND="${ANSIBLE_PLAYBOOK} ${ANSIBLE_PARAMS} ${ANSIBLE_EXTRA_PARAMS} ${PLAYBOOK}"
  echo
  echo "Running Ansible playbook: ${ANSIBLE_COMMAND}"
  eval "${ANSIBLE_COMMAND}"
done
```

with this:

```bash
for PLAYBOOK in ${PB_LIST}; do
  declare -a CMD_ARRAY=()
  CMD_ARRAY+="${ANSIBLE_PLAYBOOK}"
  CMD_ARRAY+=("${ANSIBLE_PARAMS}")
  CMD_ARRAY+=("${ANSIBLE_EXTRA_PARAMS}")
  CMD_ARRAY+=("${PLAYBOOK}")
  echo "echo Running Ansible playbook: ${CMD_ARRAY[@]}"
  ${CMD_ARRAY[@]}
done
```
That is a simplified version of what is now found in `install-oracle.sh`.

Other affected scripts have similar changes.

## Test Commands

In some cases a copy of the script was made, and the outputs from both methods of building the command line were compared.

In others, the script was run and the output examined to ensure it was correct.

With this change, the output of the ansible scripts is not really important, just that they run correctly.

There are detailed test instructions, logs and scripts in this document:

[oratk52-8-bash - detailed docs - oratk52-8-bash-cleanup.md](https://gist.github.com/jkstill/196edbd4665362f7069747e0ecd6a272)

## Expected Results

The expected result is that the ansible scripts run correctly, and that the output is as expected.

Tests of all scripts passed