### PR TITLE
Updates and optimizations to the `check-swlib` role (incl. handling URL based file names)

### DIFF
--- a/check-swlib.sh
+++ b/check-swlib.sh
@@ -129,9 +129,7 @@ done
 # Oracle Database free edition parameter overrides
 if [ "${ORA_EDITION}" = "FREE" ]; then
   ORA_DISK_MGMT=FS
-  if [[ ! "${ORA_VERSION}" =~ ^23\. ]]; then
-    ORA_VERSION="23.0.0.0.0"
-  fi
+  ORA_VERSION="23.0.0.0.0"
 fi
 
 # Mandatory options

--- a/check-swlib.sh
+++ b/check-swlib.sh
@@ -127,8 +127,11 @@ done
 }
 
 # Oracle Database free edition parameter overrides
-if [[ "${ORA_EDITION}" = "FREE" && ! "${ORA_VERSION}" =~ ^23\. ]]; then
+if [ "${ORA_EDITION}" = "FREE" ]; then
+  ORA_DISK_MGMT=FS
+  if [[ ! "${ORA_VERSION}" =~ ^23\. ]]; then
     ORA_VERSION="23.0.0.0.0"
+  fi
 fi
 
 # Mandatory options

--- a/cleanup-oracle.sh
+++ b/cleanup-oracle.sh
@@ -161,7 +161,7 @@ shopt -s nocasematch
 # (including unsupported features such as role_separation)
 if [[ "${ORA_EDITION}" = "FREE" ]]; then
     ORA_ROLE_SEPARATION=FALSE
-    [[ ! "${ORA_VERSION}" =~ ^23\. ]] && ORA_VERSION="23.0.0.0.0"
+    ORA_VERSION="23.0.0.0.0"
 fi
 
 # Mandatory options

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -898,9 +898,7 @@ if [ "${ORA_EDITION}" = "FREE" ]; then
   ORA_DISK_MGMT=FS
   ORA_ROLE_SEPARATION=FALSE
   ORA_DB_CONTAINER=TRUE
-  if [[ ! "${ORA_VERSION}" =~ ^23\. ]]; then
-    ORA_VERSION="23.0.0.0.0"
-  fi
+  ORA_VERSION="23.0.0.0.0"
   [[ ! "${ORA_DATA_DESTINATION}" =~ ^(/([^/]+))*/?$ ]] && ORA_DATA_DESTINATION="/u02/oradata" || true
   [[ ! "${ORA_RECO_DESTINATION}" =~ ^(/([^/]+))*/?$ ]] && ORA_RECO_DESTINATION="/opt/oracle/fast_recovery_area" || true
   if (( ORA_PDB_COUNT > 16 )); then

--- a/roles/check-swlib/tasks/main.yml
+++ b/roles/check-swlib/tasks/main.yml
@@ -13,22 +13,27 @@
 # limitations under the License.
 
 ---
+- name: check-swlib | Determine required installation files
+  include_role:
+    name: swlib
+    tasks_from: build_file_list.yml
+
 - name: check-swlib | Validate base software release
   shell: |
     set -o pipefail
-    if gcloud storage objects describe gs://"{{ swlib_mount_src }}"/"{{ item.1.name }}" >/dev/null 2>&1; then
-      f_name="{{ item.1.name }}"
-      expected_md5="{{ item.1.md5sum }}"
+    if gcloud storage objects describe gs://"{{ swlib_mount_src }}/{{ item.name }}" >/dev/null 2>&1; then
+      f_name="{{ item.name }}"
+      expected_md5="{{ item.md5sum }}"
     else
-      f_name="{{ item.1.alt_name | default('x') }}"
-      expected_md5="{{ item.1.alt_md5sum | default('x') }}"
+      f_name="{{ item.alt_name | default('x') }}"
+      expected_md5="{{ item.alt_md5sum | default('x') }}"
     fi
-    actual_md5=$(gcloud storage ls -L gs://"{{ swlib_mount_src }}"/"${f_name}" | awk '/MD5/ { print $3 }')
+    actual_md5=$(gcloud storage ls -L gs://"{{ swlib_mount_src }}/${f_name}" | awk '/MD5/ { print $3 }')
     if [[ "$?" -ne "0" ]] ; then
-      echo "ERROR locating {{ item.1.name }}{% if item.1.alt_name is defined and item.1.alt_name | length > 0 %} or {{ item.1.alt_name }}{% endif %}"
+      echo "ERROR locating {{ item.name }}{% if item.alt_name is defined and item.alt_name | length > 0 %} or {{ item.alt_name }}{% endif %}"
     else
       if [[ "$actual_md5" != "$expected_md5" ]]; then
-        echo "ERROR in {{ item.0.name }} md5: expected $expected_md5, but got $actual_md5 for ${f_name}"
+        echo "ERROR in {{ item.name }} md5: expected $expected_md5, but got $actual_md5 for ${f_name}"
       fi
     fi
   args:
@@ -36,92 +41,56 @@
   failed_when: "'ERROR' in base_repo_files.stdout"
   changed_when: false
   ignore_errors: true
-  loop: "{{ (((gi_software + gi_interim_patches) if ora_disk_management != 'fs' else []) + rdbms_software) | subelements('files') }}"
-  when: item.0.version == oracle_ver
+  when: item.name is not search('^https?://.*oracle\.com/.*$')
+  with_items: "{{ (gi_base_files | default([]) + rdbms_base_files) | unique }}"
   register: base_repo_files
-
-- name: check-swlib | Build list of unique RDBMS patches for GI installations
-  set_fact:
-    unique_patch_files: >-
-      {{ (rdbms_patches
-          | selectattr('release', 'equalto', oracle_rel)
-          | selectattr('category', 'equalto', 'RU_Combo')
-          | map(attribute='patchfile') | list) | unique }}
-  when: gi_install
-
-- name: check-swlib | Build list of unique RDBMS patches
-  set_fact:
-    unique_patch_files: >-
-      {{ (rdbms_patches
-          | selectattr('release', 'equalto', oracle_rel)
-          | selectattr('category', 'in', ['DB_OJVM_RU','DB_RU'])
-          | map(attribute='patchfile') | list) | unique }}
-  when: not gi_install
-
-- name: check-swlib | Capture full details for required patches
-  set_fact:
-    rdbms_patch_files: >-
-      {{ rdbms_patches
-          | selectattr('patchfile', 'in', unique_patch_files)
-          | list }}
 
 - name: check-swlib | Validate patchsets
   shell: |
     set -o pipefail
-    gcloud storage ls -L gs://{{ swlib_mount_src }}/{{ item.patchfile }} | \
-      awk '/MD5/ { print $3 }'
+    actual_md5=$(gcloud storage ls -L gs://"{{ swlib_mount_src }}/{{ item.patchfile }}" | awk '/MD5/ { print $3 }')
+    if [[ "$?" -ne "0" ]] ; then
+      echo "ERROR locating {{ item.patchfile }}"
+    else
+      if [[ "$actual_md5" != "{{ item.md5sum }}" ]]; then
+        echo "ERROR in {{ item.patchfile }} md5: expected {{ item.md5sum }}, but got $actual_md5 for {{ item.patchfile }}"
+      fi
+    fi
   args:
     executable: /bin/bash
-  failed_when: item.md5sum != patch_repo_files.stdout
+  failed_when: "'ERROR' in patch_repo_files.stdout"
   changed_when: false
   ignore_errors: true
-  with_items: >-
-    {{ rdbms_patch_files | default([]) +
-       gi_patches | default([]) if ora_disk_management != 'fs' else
-       rdbms_patch_files | default([]) }}
-  when:
-    - item.base == oracle_ver
-    - item.release == oracle_rel
+  with_items: "{{ patch_details_list | default([]) | unique }}"
   register: patch_repo_files
 
-# We can't reliably check hashes for opatch, as the same file name
+# We can't reliably check hashes for OPatch, as the same file name
 # can have different values based on version.
-- name: check-swlib | Validate opatch patches
+- name: check-swlib | Validate OPatch patches
   shell: |
     set -o pipefail
-    gcloud storage ls -L gs://{{ swlib_mount_src }}/{{ item.patchfile }} | \
+    gcloud storage ls -L gs://{{ swlib_mount_src }}/{{ item }} | \
       awk '/Content-Length/ { print $2 }'
   args:
     executable: /bin/bash
   failed_when: opatch_repo_files.stdout <= "0"
   changed_when: false
   ignore_errors: true
-  with_items: "{{ opatch_patches }}"
-  when:
-    - item.release == oracle_ver
-    - oracle_rel != "base"
+  with_items: "{{ opatch_file_list }}"
   register: opatch_repo_files
 
 - name: check-swlib | Report gcloud command failures (base)
-  fail:
-    msg: "ERROR locating {{ item.item.0.name }} {{ item.item.1.name }}: {{ item.stdout }}"
-  when: item.failed_when_result is defined and item.failed_when_result == true
-  with_items: "{{ base_repo_files.results }}"
+  assert:
+    that: item.failed is defined and not item.failed
+    quiet: true
+  with_items: "{{ base_repo_files | json_query('results[*].{name:item.name,alt_name:alt_name,failed:failed,stdout:stdout}') }}"
+  when: item.name is not search('^https?://.*oracle\.com/.*$')
 
 - name: check-swlib | Report gcloud command failures (patch)
-  fail:
-    msg: "ERROR locating {{ item.item.category }} patch {{ item.item.patchfile }}: {{ item.stderr_lines }}"
-  when: item.rc is defined and item.rc != 0
+  assert:
+    that: item.failed is defined and not item.failed
+    quiet: true
+    fail_msg: "ERROR: {{ item.category | default('') }} patch {{ item.patchfile }}: {{ item.stdout | default('') }} {{ item.stderr | default('') }}"
   with_items:
-    - "{{ patch_repo_files.results }}"
-    - "{{ opatch_repo_files.results }}"
-
-- name: check-swlib | Report MD5 mismatches (patch)
-  fail:
-    msg: |
-      MD5 mismatch: expected {{ item.item.md5sum }} got {{ item.stdout_lines }}
-      for {{ item.item.category }} patch {{ item.item.patchfile }}
-  when: item.failed is defined and item.failed
-  with_items:
-    - "{{ patch_repo_files.results }}"
-    - "{{ opatch_repo_files.results }}"
+    - "{{ patch_repo_files | json_query('results[*].{category:item.category,patchfile:item.patchfile,failed:failed,stdout:stdout,stderr:stderr}') }}"
+    - "{{ opatch_repo_files | json_query('results[*].{patchfile:item,failed:failed,stderr:stderr}') }}"

--- a/roles/check-swlib/tasks/main.yml
+++ b/roles/check-swlib/tasks/main.yml
@@ -28,7 +28,7 @@
       f_name="{{ item.alt_name | default('x') }}"
       expected_md5="{{ item.alt_md5sum | default('x') }}"
     fi
-    actual_md5=$(gcloud storage ls -L gs://"{{ swlib_mount_src }}/${f_name}" | awk '/MD5/ { print $3 }')
+    actual_md5=$(gcloud storage objects describe gs://"{{ swlib_mount_src }}/${f_name}" --format="value(md5Hash)")
     if [[ "$?" -ne "0" ]] ; then
       echo "ERROR locating {{ item.name }}{% if item.alt_name is defined and item.alt_name | length > 0 %} or {{ item.alt_name }}{% endif %}"
     else
@@ -48,7 +48,7 @@
 - name: check-swlib | Validate patchsets
   shell: |
     set -o pipefail
-    actual_md5=$(gcloud storage ls -L gs://"{{ swlib_mount_src }}/{{ item.patchfile }}" | awk '/MD5/ { print $3 }')
+    actual_md5=$(gcloud storage objects describe gs://"{{ swlib_mount_src }}/{{ item.patchfile }}" --format="value(md5Hash)")
     if [[ "$?" -ne "0" ]] ; then
       echo "ERROR locating {{ item.patchfile }}"
     else
@@ -68,9 +68,7 @@
 # can have different values based on version.
 - name: check-swlib | Validate OPatch patches
   shell: |
-    set -o pipefail
-    gcloud storage ls -L gs://{{ swlib_mount_src }}/{{ item }} | \
-      awk '/Content-Length/ { print $2 }'
+    gcloud storage objects describe gs://"{{ swlib_mount_src }}/{{ item }}" --format="value(size)"
   args:
     executable: /bin/bash
   failed_when: opatch_repo_files.stdout <= "0"

--- a/roles/swlib/tasks/build_file_list.yml
+++ b/roles/swlib/tasks/build_file_list.yml
@@ -32,7 +32,7 @@
 - name: build_file_list | Build list of GI base software and interim patches
   set_fact:
     gi_base_files: >-
-      {{ gi_software
+      {{ (gi_software + gi_interim_patches)
          | selectattr('version', 'equalto', oracle_ver)
          | map(attribute='files')
          | flatten


### PR DESCRIPTION
## Change Overview:

Updates to the **check-swlib** scripts to handle new situations including the possibility of a URL in a file name. Meaning that the required installation software is downloaded from oracle-dot-com and not sourced from the software library.

Key changes include:

1. There is already significant logic in determining what files are required in the `build_file_list.yml` task file. This file also, optionally, checks that the available OPatch version is sufficiently recent. Therefore, instead of redoing much of that logic in a separate task file, the `check-swlib` role can simply run that same task file.

2. If the file `name` key has a URL, then the swlib validation task is skipped. As the medial will be sourced form the URL.

## Test Results:

Expected successful results:

- [Test using "latest" Free edition with URL file names](https://gist.github.com/simonpane/dc5d60e251f4eadeaf4a452b4be259d0)
- [Test using "latest" Free edition with swlib file names](https://gist.github.com/simonpane/8dff27e21f0a1c297269414b8919eb10)
- [Test using older Free edition with files available in swlib](https://gist.github.com/simonpane/8022c68d6f94d80e418df40132907a96)
- [Regression test of 19c EE software](https://gist.github.com/simonpane/2646dd5667d7d6948f8bc9a222d59aac)
- [Test of older 12.1 version with interim patch requirement](https://gist.github.com/simonpane/4da69dbd3be8f6bd64d46abe5e808db2)

Executions with expected failures:

- [Test using older Free edition with a file MD5 mismatch](https://gist.github.com/simonpane/024c7cb1309d3d90465647e8ff6309a3)
- [Test when the base software file cannot be found](https://gist.github.com/simonpane/28964a8247f55ad0d504b19adb563a2f)
- [Test when the base software file has an MD5 mismatch](https://gist.github.com/simonpane/c9613696f1205f668f22638d4b5856b3)
- [Test when the patchfile cannot be found](https://gist.github.com/simonpane/19ae18c755505fed63da1f30f1c87de9)
- [Test when the patchfile has an MD5 mis-match](https://gist.github.com/simonpane/2717a2e61a5d03b56928b03499d0c3d3)