### PR TITLE
Add start/stop script to cleanup

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -52,6 +52,17 @@
     - cluster_name is not defined
     - not free_edition
 
+- name: Shut down and disable the dbora systemd service
+  ansible.builtin.systemd:
+    name: "dbora.service"
+    state: stopped
+    enabled: false
+  when:
+    - cluster_type != "RAC"
+    - not free_edition
+  ignore_errors: true
+  tags: remove-systemd
+
 - name: Free Edition cleanup steps
   become: true
   become_user: root
@@ -281,6 +292,12 @@
     - "/var/log/oracleohasd"
   ignore_errors: true
   register: remove_files
+
+- name: Reload systemd daemon to unregister the removed services
+  ansible.builtin.systemd:
+    daemon_reload: true
+  ignore_errors: true
+  tags: reload-systemd
 
 - name: Clean up shared memory segments
   become: true


### PR DESCRIPTION
With the addition of #355 we now have a start/stop script for filesystem installs. Here we add logic to attempt to use it to shut down the database cleanup before a cleanup, and also to remove the service before systemd attempts to restart it.

We attempt to preserve the existing semantics of the cleanup script here:  to favor ignoring errors over complex "when" clauses, so as to reduce the dependencies on getting parameters exactly right.

The systemd reload should also help with any other systemd services we cleanup, like Oracle TFA.

Sample output from a test run (actually a re-run after a few bugfixes): https://gist.github.com/mfielding/2b5e34df98d0bb7260c2055efb27b477