### PR TITLE
Handle base release versions

### DIFF
--- a/roles/common/tasks/populate-vars.yml
+++ b/roles/common/tasks/populate-vars.yml
@@ -18,11 +18,17 @@
     oracle_rel: "{{ found_rel | trim }}"
   vars:
     found_rel: >-
+      {% set base_release = (gi_patches | selectattr('base', 'equalto', oracle_ver) | list | first | default({})).base | default('') %}
+      {% set latest_release = (gi_patches | selectattr('base', 'equalto', oracle_ver) | list | last | default({})).release | default('base') %}
+      {% set matched_patch = gi_patches | selectattr('base', 'equalto', oracle_ver) | selectattr('release', 'equalto', oracle_rel) | list | first %}
       {% if oracle_rel == "latest" %}
-        {{ (gi_patches | selectattr('base', 'equalto', oracle_ver) | list | last | default({})).release | default('base') }}
+        {{ latest_release }}
+      {% elif oracle_rel == base_release %}
+        base
+      {% elif matched_patch is defined %}
+        {{ matched_patch.release }}
       {% else %}
-        {% set matched_patch = gi_patches | selectattr('base', 'equalto', oracle_ver) | selectattr('release', 'equalto', oracle_rel) | list | first %}
-        {{ matched_patch.release | default((gi_patches | selectattr('base', 'equalto', oracle_ver) | list | last | default({})).release) if matched_patch is defined else (gi_patches | selectattr('base', 'equalto', oracle_ver) | list | last | default({})).release }}
+        {{ latest_release }}
       {% endif %}
   when:
     - not free_edition


### PR DESCRIPTION
The release selection logic in roles/common/tasks/populate-vars.yml did not correctly handle cases where a base release version (e.g., "19.3.0.0.0") was specified for "ora_release" variable in terraform. This caused the playbook to ignore the specified version and default to the latest available patch.


 The updated logic in populate-vars.yml now makes sure the correct release is selected:

* If oracle_rel is "latest", the latest release is used.
* If oracle_rel is "base", it will remain "base".
* If oracle_rel matches the base release (e.g., "19.3.0.0.0"), it will be set to "base".
* If oracle_rel matches a release in the gi_patches list, that specific patch will be used.
* Otherwise, it defaults to the latest release.

internal bug: b/448723943

Test Results:


```
$ ./test_check_swlib.sh
+ ./check-swlib.sh --ora-version 19 --ora-swlib-bucket gs://bmaas-testing-oracle-software --ora-release 19.23.0.0.240416
+ egrep oracle_rel
    "oracle_rel": "19.23.0.0.240416"
+ ./check-swlib.sh --ora-version 19 --ora-swlib-bucket gs://bmaas-testing-oracle-software --ora-release base
+ egrep oracle_rel
    "oracle_rel": "base"
+ ./check-swlib.sh --ora-version 19 --ora-swlib-bucket gs://bmaas-testing-oracle-software --ora-release latest
+ egrep oracle_rel
    "oracle_rel": "19.28.0.0.250715"
+ egrep oracle_rel
+ ./check-swlib.sh --ora-version 19 --ora-swlib-bucket gs://bmaas-testing-oracle-software --ora-release 19.3.0.0.0
    "oracle_rel": "base"
+ ./check-swlib.sh --ora-version 19 --ora-swlib-bucket gs://bmaas-testing-oracle-software --ora-release 19.99.0.0.0
+ egrep oracle_rel
    "oracle_rel": "19.28.0.0.250715"
```
